### PR TITLE
Report List View: RF_GSC_2

### DIFF
--- a/src/firestore.rules
+++ b/src/firestore.rules
@@ -121,7 +121,7 @@ service cloud.firestore {
     }
 
     // Rules for Single Reports (NOT Queries!!)
-    match /reports/{idReport} {
+    match /reports/{city}/{city_report}/{idReport} {
       // Allow read from citizen or municipality (only same city):
       allow read: if isCitizen() ||
           (isMunicipality() &&

--- a/src/lib/gestione_segnalazione_cittadino/gestione_segnalazione_cittadino_DAO.dart
+++ b/src/lib/gestione_segnalazione_cittadino/gestione_segnalazione_cittadino_DAO.dart
@@ -1,3 +1,0 @@
-class CitizenReportManagementDAO {
-    
-}

--- a/src/lib/gestione_segnalazione_cittadino/gestione_segnalazione_cittadino_controller.dart
+++ b/src/lib/gestione_segnalazione_cittadino/gestione_segnalazione_cittadino_controller.dart
@@ -17,7 +17,7 @@ class CitizenReportManagementController{
   /// \param user The [Citizen] object representing the user whose reports are to be fetched.
   ///
   /// \return A [Future] that resolves to a list of maps, where each map contains the report details.
-  Future<List<Map<String, dynamic>>> getUserReports(Citizen user) async {
-    return await _reportDAO.getReportList(user.city ?? '') ?? [];
+  Future<List<Map<String, dynamic>>?> getUserReports(Citizen user) async {
+    return await _reportDAO.getReportList(user.city ?? '');
   }
 }

--- a/src/lib/gestione_segnalazione_cittadino/gestione_segnalazione_cittadino_controller.dart
+++ b/src/lib/gestione_segnalazione_cittadino/gestione_segnalazione_cittadino_controller.dart
@@ -1,3 +1,23 @@
-class CitizenReportManagementController{
+import '../model/users_model.dart';
+import 'gestione_segnalazione_cittadino_dao.dart';
 
+
+/// Controller for managing citizen reports.
+///
+/// This controller provides methods to interact with the data access object (DAO)
+/// for fetching and managing reports related to citizens.
+class CitizenReportManagementController{
+  final CitizenReportManagementDAO _reportDAO = CitizenReportManagementDAO();
+
+  /// Fetches the list of reports for a given citizen.
+  ///
+  /// This method retrieves the list of reports associated with the city of the provided citizen.
+  /// If the city is not available, it returns an empty list.
+  ///
+  /// \param user The [Citizen] object representing the user whose reports are to be fetched.
+  ///
+  /// \return A [Future] that resolves to a list of maps, where each map contains the report details.
+  Future<List<Map<String, dynamic>>> getUserReports(Citizen user) async {
+    return await _reportDAO.getReportList(user.city ?? '') ?? [];
+  }
 }

--- a/src/lib/gestione_segnalazione_cittadino/gestione_segnalazione_cittadino_controller.dart
+++ b/src/lib/gestione_segnalazione_cittadino/gestione_segnalazione_cittadino_controller.dart
@@ -14,7 +14,7 @@ class CitizenReportManagementController {
   /// Data Access Object (DAO) for managing citizen reports.
   late final CitizenReportManagementDAO _reportDAO;
   late final UserManagementDAO _userManagementDAO;
-  late final Citizen _citizen;
+  Citizen? _citizen;
   DocumentSnapshot? _lastDocument;
   final Completer<Citizen> _citizenCompleter = Completer<Citizen>();
 
@@ -70,12 +70,12 @@ class CitizenReportManagementController {
   ///
   ///  - [Returns]: A [Future] that resolves to a list of maps, where each map contains the report details.
   Future<List<Map<String, dynamic>>?> getUserReports() async {
-    if(_citizen.city == null){
+    if(_citizen!.city == null){
       return [];
     }
 
      List<Map<String, dynamic>>? snapshot = await _reportDAO.getReportList(
-         city:_citizen.city!,
+         city:_citizen!.city!,
          lastDocument: _lastDocument
      );
     _lastDocument = snapshot?.last['documentSnapshot'];

--- a/src/lib/gestione_segnalazione_cittadino/gestione_segnalazione_cittadino_controller.dart
+++ b/src/lib/gestione_segnalazione_cittadino/gestione_segnalazione_cittadino_controller.dart
@@ -68,12 +68,13 @@ class CitizenReportManagementController {
   /// This method retrieves the list of reports associated with the city of the provided citizen.
   /// If the city is not available, it returns an empty list.
   ///
-  ///  - [reset]: A `bool` indicating whether to reset the last document retrieved.
+  /// - [reset]: A `bool` indicating whether to reset the last document retrieved.
   ///   If the [reset] parameter is set to `true`, the method will reset the last document retrieved.
   ///
-  ///  - [Returns]: A [Future] that resolves to a list of maps, where each map contains the report details.
+  /// Returns:
+  /// - A [Future] that resolves to a list of maps, where each map contains the report details.
   Future<List<Map<String, dynamic>>?> getUserReports({bool reset = false}) async {
-    if(_citizen!.city == null){
+    if(_citizen == null || _citizen!.city == null){
       return [];
     }
     if(reset){

--- a/src/lib/gestione_segnalazione_cittadino/gestione_segnalazione_cittadino_controller.dart
+++ b/src/lib/gestione_segnalazione_cittadino/gestione_segnalazione_cittadino_controller.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:civiconnect/user_management/user_management_dao.dart';
-import 'package:cloud_firestore/cloud_firestore.dart';
 
 import '../model/users_model.dart';
 import 'gestione_segnalazione_cittadino_dao.dart';
@@ -15,7 +14,6 @@ class CitizenReportManagementController {
   late final CitizenReportManagementDAO _reportDAO;
   late final UserManagementDAO _userManagementDAO;
   Citizen? _citizen;
-  DocumentSnapshot? _lastDocument;
   final Completer<Citizen> _citizenCompleter = Completer<Citizen>();
 
   /// Constructs a new `CitizenReportManagementController` instance.
@@ -28,7 +26,7 @@ class CitizenReportManagementController {
     CitizenReportManagementDAO? reportDAO,
     UserManagementDAO? userManagementDAO,
   }) {
-    _reportDAO = reportDAO ?? MockCitizenReportManagementDAO();
+    _reportDAO = reportDAO ?? CitizenReportManagementDAO();
     _userManagementDAO = userManagementDAO ?? UserManagementDAO();
     _loadCitizen();
   }
@@ -77,23 +75,12 @@ class CitizenReportManagementController {
     if(_citizen == null || _citizen!.city == null){
       return [];
     }
-    if(reset){
-      _lastDocument = null;
-    }
+
 
     List<Map<String, dynamic>>? snapshot = await _reportDAO.getReportList(
         city:_citizen!.city!,
-        lastDocument: _lastDocument,
         reset: reset
     );
-    /// Retrieves the last document from the snapshot and updates the last document field.
-    /// Last DocumentSnapshot is added by the DAO to the last element of the list.
-    /// If the snapshot is empty, the last document is set to null.
-    var lastDocument = snapshot?.last['lastDocument'];
-    if(lastDocument is DocumentSnapshot){
-      snapshot?.removeLast();
-    }
-    _lastDocument = lastDocument;
     return snapshot;
   }
 }

--- a/src/lib/gestione_segnalazione_cittadino/gestione_segnalazione_cittadino_controller.dart
+++ b/src/lib/gestione_segnalazione_cittadino/gestione_segnalazione_cittadino_controller.dart
@@ -68,17 +68,31 @@ class CitizenReportManagementController {
   /// This method retrieves the list of reports associated with the city of the provided citizen.
   /// If the city is not available, it returns an empty list.
   ///
+  ///  - [reset]: A `bool` indicating whether to reset the last document retrieved.
+  ///   If the [reset] parameter is set to `true`, the method will reset the last document retrieved.
+  ///
   ///  - [Returns]: A [Future] that resolves to a list of maps, where each map contains the report details.
-  Future<List<Map<String, dynamic>>?> getUserReports() async {
+  Future<List<Map<String, dynamic>>?> getUserReports({bool reset = false}) async {
     if(_citizen!.city == null){
       return [];
     }
+    if(reset){
+      _lastDocument = null;
+    }
 
-     List<Map<String, dynamic>>? snapshot = await _reportDAO.getReportList(
-         city:_citizen!.city!,
-         lastDocument: _lastDocument
-     );
-    _lastDocument = snapshot?.last['documentSnapshot'];
+    List<Map<String, dynamic>>? snapshot = await _reportDAO.getReportList(
+        city:_citizen!.city!,
+        lastDocument: _lastDocument,
+        reset: reset
+    );
+    /// Retrieves the last document from the snapshot and updates the last document field.
+    /// Last DocumentSnapshot is added by the DAO to the last element of the list.
+    /// If the snapshot is empty, the last document is set to null.
+    var lastDocument = snapshot?.last['lastDocument'];
+    if(lastDocument is DocumentSnapshot){
+      snapshot?.removeLast();
+    }
+    _lastDocument = lastDocument;
     return snapshot;
   }
 }

--- a/src/lib/gestione_segnalazione_cittadino/gestione_segnalazione_cittadino_controller.dart
+++ b/src/lib/gestione_segnalazione_cittadino/gestione_segnalazione_cittadino_controller.dart
@@ -33,6 +33,12 @@ class CitizenReportManagementController {
     _loadCitizen();
   }
 
+  /// Loads the current citizen user.
+  ///
+  /// This method determines the user type and initializes the `_citizen` field if the user is a citizen.
+  ///
+  /// Throws:
+  /// - [Exception]: If the user is not logged in or is not a citizen.
   void _loadCitizen() async {
     try {
       final user = await _userManagementDAO.determineUserType();
@@ -53,7 +59,7 @@ class CitizenReportManagementController {
     }
   }
 
-  /// Restituisce il cittadino dopo che è stato inizializzato.
+  /// Returns the current citizen user.
   Future<Citizen> get citizen async => _citizenCompleter.future;
 
 
@@ -62,7 +68,7 @@ class CitizenReportManagementController {
   /// This method retrieves the list of reports associated with the city of the provided citizen.
   /// If the city is not available, it returns an empty list.
   ///
-  /// \return A [Future] that resolves to a list of maps, where each map contains the report details.
+  ///  - [Returns]: A [Future] that resolves to a list of maps, where each map contains the report details.
   Future<List<Map<String, dynamic>>?> getUserReports() async {
     if(_citizen.city == null){
       return [];

--- a/src/lib/gestione_segnalazione_cittadino/gestione_segnalazione_cittadino_controller.dart
+++ b/src/lib/gestione_segnalazione_cittadino/gestione_segnalazione_cittadino_controller.dart
@@ -1,23 +1,78 @@
+import 'dart:async';
+
+import 'package:civiconnect/user_management/user_management_dao.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
 import '../model/users_model.dart';
 import 'gestione_segnalazione_cittadino_dao.dart';
-
 
 /// Controller for managing citizen reports.
 ///
 /// This controller provides methods to interact with the data access object (DAO)
 /// for fetching and managing reports related to citizens.
-class CitizenReportManagementController{
-  final CitizenReportManagementDAO _reportDAO = CitizenReportManagementDAO();
+class CitizenReportManagementController {
+  /// Data Access Object (DAO) for managing citizen reports.
+  late final CitizenReportManagementDAO _reportDAO;
+  late final UserManagementDAO _userManagementDAO;
+  late final Citizen _citizen;
+  DocumentSnapshot? _lastDocument;
+  final Completer<Citizen> _citizenCompleter = Completer<Citizen>();
+
+  /// Constructs a new `CitizenReportManagementController` instance.
+  /// [reportDAO] An optional instance of `CitizenReportManagementDAO`.
+  /// If not provided, a new instance of `CitizenReportManagementDAO` will be created.
+  /// [userManagementDAO] An optional instance of `UserManagementDAO`.
+  /// If not provided, a new instance of `UserManagementDAO` will be created.
+
+  CitizenReportManagementController({
+    CitizenReportManagementDAO? reportDAO,
+    UserManagementDAO? userManagementDAO,
+  }) {
+    _reportDAO = reportDAO ?? MockCitizenReportManagementDAO();
+    _userManagementDAO = userManagementDAO ?? UserManagementDAO();
+    _loadCitizen();
+  }
+
+  void _loadCitizen() async {
+    try {
+      final user = await _userManagementDAO.determineUserType();
+      if (user == null) {
+        throw Exception('User not logged in');
+      }
+
+      if (user is Citizen) {
+        _citizen = user;
+        _citizenCompleter.complete(user); // Segnala che l'inizializzazione è completa
+
+      } else {
+        throw Exception('User is not a citizen');
+      }
+
+    } catch (e) {
+      _citizenCompleter.completeError('Error determining user type: $e');
+    }
+  }
+
+  /// Restituisce il cittadino dopo che è stato inizializzato.
+  Future<Citizen> get citizen async => _citizenCompleter.future;
+
 
   /// Fetches the list of reports for a given citizen.
   ///
   /// This method retrieves the list of reports associated with the city of the provided citizen.
   /// If the city is not available, it returns an empty list.
   ///
-  /// \param user The [Citizen] object representing the user whose reports are to be fetched.
-  ///
   /// \return A [Future] that resolves to a list of maps, where each map contains the report details.
-  Future<List<Map<String, dynamic>>?> getUserReports(Citizen user) async {
-    return await _reportDAO.getReportList(user.city ?? '');
+  Future<List<Map<String, dynamic>>?> getUserReports() async {
+    if(_citizen.city == null){
+      return [];
+    }
+
+     List<Map<String, dynamic>>? snapshot = await _reportDAO.getReportList(
+         city:_citizen.city!,
+         lastDocument: _lastDocument
+     );
+    _lastDocument = snapshot?.last['documentSnapshot'];
+    return snapshot;
   }
 }

--- a/src/lib/gestione_segnalazione_cittadino/gestione_segnalazione_cittadino_dao.dart
+++ b/src/lib/gestione_segnalazione_cittadino/gestione_segnalazione_cittadino_dao.dart
@@ -10,6 +10,11 @@ class CitizenReportManagementDAO {
   final UserManagementDAO _userManagementDAO;
   /// The Firestore instance.
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  /// The last document retrieved in the previous query.
+  DocumentSnapshot? _lastDocument;
+
+  /// Specifies it the query offset is at the bottom of the list.
+  bool _isEnded = false;
 
 
   /// Constructs a new `CitizenReportManagementDAO` instance.
@@ -32,11 +37,17 @@ class CitizenReportManagementDAO {
   ///
   /// Preconditions:
   /// - The user must be logged in and either a `Municipality` with the specified city name or a `Citizen`.
-  Future<List<Map<String, dynamic>>?> getReportList({required String city, DocumentSnapshot? lastDocument, bool? reset}) async {
-      if(! await _checkForUserValidity(city)) {
+  Future<List<Map<String, dynamic>>?> getReportList({required String city, bool? reset}) async {
+      if(reset == true){
+        _isEnded = false;
+        _lastDocument = null;
+      }
+
+      if(! await _checkForUserValidity(city) || _isEnded){
         return null;
       }
-      return await _getTenReportsByOffset(city: city, lastDocument: lastDocument, reset: reset);
+
+      return await _getTenReportsByOffset(city: city);
   }
 
 
@@ -54,25 +65,33 @@ class CitizenReportManagementDAO {
   ///
   /// Throws:
   /// - [Exception]: If there is an error retrieving the data.
-Future<List<Map<String, dynamic>>?> _getTenReportsByOffset({required String city, DocumentSnapshot? lastDocument, bool? reset}) async {
+Future<List<Map<String, dynamic>>?> _getTenReportsByOffset({required String city}) async {
   Query<Map<String, dynamic>> query = _firestore.collection('reports').doc(city.toLowerCase()).collection('${city.toLowerCase()}_reports')
     .orderBy('title', descending: true).limit(10);
 
-  if (lastDocument != null) {
-    query = query.startAfterDocument(lastDocument);
-  }
-
-  if(reset == true){
-    lastDocument = null;
+  // If the last document is not null, the query starts after the last document of the previous query.
+  if (_lastDocument != null) {
+    query = query.startAfterDocument(_lastDocument!);
   }
 
   try {
     final querySnapshot = await query.get();
-    if (querySnapshot.docs.isEmpty) {
+    // If the query is empty or the last document is the same as the previous one, the query is ended.
+    if (_isEnded || querySnapshot.docs.isEmpty || _lastDocument == querySnapshot.docs.last){
+      _isEnded = true;
       return null;
     }
+
+    // If the query is less than 10, the query is ended but the last documents are updated.
+    if(querySnapshot.docs.length < 10){
+      _isEnded = true;
+    }
+
+    //Retrieve the data from the query snapshot.
     var data = querySnapshot.docs.map((doc) => doc.data()).toList();
-    data.add({'lastDocument' : querySnapshot.docs.last});
+    // Update the last document.
+    _lastDocument  = querySnapshot.docs.last;
+
     return data;
 
   } catch (e) {
@@ -119,7 +138,7 @@ class MockCitizenReportManagementDAO extends Mock implements CitizenReportManage
   late final List<Map<String, dynamic>> reports;
 
   /// The index of the last document retrieved. MOCK
-  int _lastDocument = 0;
+  int _lastDocumentIndex = 0;
 
   /// Constructs a new `MockCitizenReportManagementDAO` instance.
   /// Parameters:
@@ -153,23 +172,20 @@ class MockCitizenReportManagementDAO extends Mock implements CitizenReportManage
   }
 
   @override
-  Future<List<Map<String, dynamic>>?> getReportList({required String city, DocumentSnapshot? lastDocument, bool? reset}) async {
+  Future<List<Map<String, dynamic>>?> getReportList({required String city, bool? reset}) async {
     if(reset == true){
-      _lastDocument = 0;
+      _lastDocumentIndex = 0;
     }
 
-    if(_lastDocument == 0){
-      _lastDocument = 10;
-     return Future.value(reports.sublist(0, 10));
-
-    } else {
-      if(_lastDocument >= 30){
-        return Future.value(null);
-      }
-      int index = _lastDocument;
-      _lastDocument = index + 10;
-      return Future.value(reports.sublist(index, index + 10));
+    if(_lastDocumentIndex >= 30){
+      return Future.value(null);
     }
+
+    int index = _lastDocumentIndex;
+    _lastDocumentIndex = index + 10;
+    return Future.value(reports.sublist(index, index + 10));
   }
+
+
 
 }

--- a/src/lib/gestione_segnalazione_cittadino/gestione_segnalazione_cittadino_dao.dart
+++ b/src/lib/gestione_segnalazione_cittadino/gestione_segnalazione_cittadino_dao.dart
@@ -1,0 +1,108 @@
+import 'package:civiconnect/model/users_model.dart';
+import 'package:civiconnect/user_management/user_management_dao.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// Data Access Object (DAO) for managing citizen reports.
+class CitizenReportManagementDAO {
+  final UserManagementDAO _userManagementDAO;
+
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+
+
+  /// Constructs a new `CitizenReportManagementDAO` instance.
+  ///
+  /// Parameters:
+  /// - [userManagementDAO]: An optional instance of `UserManagementDAO`. If not provided, a new instance of `UserManagementDAO` will be created.
+  CitizenReportManagementDAO({UserManagementDAO? userManagementDAO}) : _userManagementDAO = userManagementDAO ?? UserManagementDAO();
+
+  /// Retrieves a list of reports for a given city.
+  ///
+  /// Parameters:
+  /// - [city]: The name of the city for which to retrieve the reports.
+  ///
+  /// Returns:
+  /// - A `Future<List<Map<String, dynamic>>>` containing the list of reports for the specified city, or `null` if the user is not valid.
+  ///
+  /// Throws:
+  /// - [Exception]: If the user is not logged in.
+  ///
+  /// Preconditions:
+  /// - The user must be logged in and either a `Municipality` with the specified city name or a `Citizen`.
+  Future<List<Map<String, dynamic>>>? getReportList(String city){
+      if(!_checkForUserValidity(city)) {
+        return null;
+      }
+      return _getTenReportsByOffset(city: city);
+  }
+
+
+
+  /* --------------------------- PRIVATE METHODS ---------------------------------- */
+
+  /// Retrieves the next ten reports for a given city, starting from the last retrieved report.
+  ///
+  /// Parameters:
+  /// - [city]: The name of the city for which to retrieve the reports.
+  ///
+  /// Returns:
+  /// - A `Future<List<Map<String, dynamic>>>` containing the next ten reports for the specified city.
+  ///
+  /// Throws:
+  /// - [Exception]: If there is an error retrieving the data.
+  Future<List<Map<String, dynamic>>> _getTenReportsByOffset({required String city}) async {
+    //final reports = await _firestore.collection(getPath(city, null)).orderBy('creationDate', descending: true).startAt([offset]).limit(10).get();
+    final first = _firestore.collection(_getPath(city, null)).orderBy('creationDate', descending: true).limit(10);
+    return first.get().then(
+          (documentSnapshots) {
+        // Get the last visible document
+        final lastVisible = documentSnapshots.docs[documentSnapshots.size - 1];
+
+        // Construct a new query starting at this document,
+        // get the next 25 cities.
+        final next = _firestore
+            .collection(_getPath(city, null))
+            .orderBy('creationDate', descending: true)
+            .startAfterDocument(lastVisible)
+            .limit(10);
+      },
+      onError: (e) => throw Exception('Errore nella ricerca dei dati'),
+    ) as List<Map<String, dynamic>>;
+  }
+
+
+  /* -------------------------------- UTILITY PRIVATE METHODS ----------------------------- */
+
+  /// Returns the path to the report(s) in the database for the given city and report ID.
+  ///
+  /// Parameters:
+  /// - [city]: The name of the city.
+  /// - [reportId]: The unique identifier of the report. If `null`, returns the path to all reports in the specified city.
+  ///
+  /// Returns:
+  /// - A `String` representing the path to the report(s) in the database.
+  String _getPath(String city, String? reportId) {
+    if (reportId == null) {
+      return 'reports/$city/${city}_reports';
+    }
+    return 'reports/$city/${city}_reports/$reportId';
+  }
+
+  /// Checks if the current user is valid for the given city.
+  ///
+  /// Parameters:
+  /// - [city]: The name of the city to check.
+  ///
+  /// Returns:
+  /// - A `bool` indicating whether the user is valid for the specified city.
+  ///
+  /// Throws:
+  /// - [Exception]: If the user is not logged in.
+  bool _checkForUserValidity(String? city) {
+    GenericUser? user = _userManagementDAO.getUser;
+    if (user == null) {
+      throw Exception('Utente non loggato!');
+    }
+    return (user is Municipality && (user).municipalityName == city) || user is Citizen;
+  }
+
+}

--- a/src/lib/gestione_segnalazione_cittadino/gestione_segnalazione_cittadino_dao.dart
+++ b/src/lib/gestione_segnalazione_cittadino/gestione_segnalazione_cittadino_dao.dart
@@ -5,8 +5,10 @@ import 'package:mockito/mockito.dart';
 
 /// Data Access Object (DAO) for managing citizen reports.
 class CitizenReportManagementDAO {
-  final UserManagementDAO _userManagementDAO;
 
+  /// The data access object for user management.
+  final UserManagementDAO _userManagementDAO;
+  /// The Firestore instance.
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
 
 
@@ -20,6 +22,7 @@ class CitizenReportManagementDAO {
   ///
   /// Parameters:
   /// - [city]: The name of the city for which to retrieve the reports.
+  /// - [lastDocument]: The last document retrieved in the previous query (optional).
   ///
   /// Returns:
   /// - A `Future<List<Map<String, dynamic>>?>` containing the list of reports for the specified city, or `null` if the user is not valid.
@@ -44,12 +47,13 @@ class CitizenReportManagementDAO {
   ///
   /// Parameters:
   /// - [city]: The name of the city for which to retrieve the reports.
+  /// - [lastDocument]: The last document retrieved in the previous query (optional).
   ///
   /// Returns:
   /// - A `Future<List<Map<String, dynamic>>>` containing the next ten reports for the specified city.
-  ////
-/// Throws:
-/// - [Exception]: If there is an error retrieving the data.
+  ///
+  /// Throws:
+  /// - [Exception]: If there is an error retrieving the data.
 Future<List<Map<String, dynamic>>?> _getTenReportsByOffset({required String city, DocumentSnapshot? lastDocument}) async {
   Query<Map<String, dynamic>> query = _firestore.collection('reports').doc(city.toLowerCase()).collection('${city.toLowerCase()}_reports')
     .orderBy('title', descending: true).limit(10);
@@ -94,7 +98,10 @@ Future<List<Map<String, dynamic>>?> _getTenReportsByOffset({required String city
 }
 
 
-/// Mock implementation of the `CitizenReportManagementDAO` class.
+/// Constructs a new `MockCitizenReportManagementDAO` instance.
+///
+/// Parameters:
+/// - [userManagementDAO]: An optional instance of `UserManagementDAO`. If not provided, a new instance of `UserManagementDAO` will be created.
 class MockCitizenReportManagementDAO extends Mock implements CitizenReportManagementDAO {
   /// The mock implementation of the `UserManagementDAO` class.
   /// Could be passed in the constructor.

--- a/src/lib/gestione_segnalazione_cittadino/gestione_segnalazione_cittadino_dao.dart
+++ b/src/lib/gestione_segnalazione_cittadino/gestione_segnalazione_cittadino_dao.dart
@@ -21,18 +21,18 @@ class CitizenReportManagementDAO {
   /// - [city]: The name of the city for which to retrieve the reports.
   ///
   /// Returns:
-  /// - A `Future<List<Map<String, dynamic>>>` containing the list of reports for the specified city, or `null` if the user is not valid.
+  /// - A `Future<List<Map<String, dynamic>>?>` containing the list of reports for the specified city, or `null` if the user is not valid.
   ///
   /// Throws:
   /// - [Exception]: If the user is not logged in.
   ///
   /// Preconditions:
   /// - The user must be logged in and either a `Municipality` with the specified city name or a `Citizen`.
-  Future<List<Map<String, dynamic>>>? getReportList(String city){
-      if(!_checkForUserValidity(city)) {
+  Future<List<Map<String, dynamic>>?> getReportList(String city) async {
+      if(! await _checkForUserValidity(city)) {
         return null;
       }
-      return _getTenReportsByOffset(city: city);
+      return await _getTenReportsByOffset(city: city);
   }
 
 
@@ -46,46 +46,22 @@ class CitizenReportManagementDAO {
   ///
   /// Returns:
   /// - A `Future<List<Map<String, dynamic>>>` containing the next ten reports for the specified city.
-  ///
-  /// Throws:
-  /// - [Exception]: If there is an error retrieving the data.
-  Future<List<Map<String, dynamic>>> _getTenReportsByOffset({required String city}) async {
-    //final reports = await _firestore.collection(getPath(city, null)).orderBy('creationDate', descending: true).startAt([offset]).limit(10).get();
-    final first = _firestore.collection(_getPath(city, null)).orderBy('creationDate', descending: true).limit(10);
-    return first.get().then(
-          (documentSnapshots) {
-        // Get the last visible document
-        final lastVisible = documentSnapshots.docs[documentSnapshots.size - 1];
-
-        // Construct a new query starting at this document,
-        // get the next 25 cities.
-        final next = _firestore
-            .collection(_getPath(city, null))
-            .orderBy('creationDate', descending: true)
-            .startAfterDocument(lastVisible)
-            .limit(10);
-      },
-      onError: (e) => throw Exception('Errore nella ricerca dei dati'),
-    ) as List<Map<String, dynamic>>;
+  ////
+/// Throws:
+/// - [Exception]: If there is an error retrieving the data.
+Future<List<Map<String, dynamic>>?> _getTenReportsByOffset({required String city}) async {
+  final first = _firestore.collection('reports').doc(city.toLowerCase()).collection('${city.toLowerCase()}_reports')
+    .orderBy('title', descending: true).limit(10);
+  try {
+    final querySnapshot = await first.get();
+    final data = querySnapshot.docs.map((doc) => doc.data()).toList();
+    return data;
+  } catch (e) {
+    throw Exception('Error retrieving data: $e');
   }
-
-
+}
   /* -------------------------------- UTILITY PRIVATE METHODS ----------------------------- */
 
-  /// Returns the path to the report(s) in the database for the given city and report ID.
-  ///
-  /// Parameters:
-  /// - [city]: The name of the city.
-  /// - [reportId]: The unique identifier of the report. If `null`, returns the path to all reports in the specified city.
-  ///
-  /// Returns:
-  /// - A `String` representing the path to the report(s) in the database.
-  String _getPath(String city, String? reportId) {
-    if (reportId == null) {
-      return 'reports/$city/${city}_reports';
-    }
-    return 'reports/$city/${city}_reports/$reportId';
-  }
 
   /// Checks if the current user is valid for the given city.
   ///
@@ -97,8 +73,8 @@ class CitizenReportManagementDAO {
   ///
   /// Throws:
   /// - [Exception]: If the user is not logged in.
-  bool _checkForUserValidity(String? city) {
-    GenericUser? user = _userManagementDAO.getUser;
+  Future<bool> _checkForUserValidity(String? city) async {
+    GenericUser? user = await _userManagementDAO.determineUserType();
     if (user == null) {
       throw Exception('Utente non loggato!');
     }

--- a/src/lib/gestione_segnalazione_cittadino/gestione_segnalazione_cittadino_dao.dart
+++ b/src/lib/gestione_segnalazione_cittadino/gestione_segnalazione_cittadino_dao.dart
@@ -1,6 +1,7 @@
 import 'package:civiconnect/model/users_model.dart';
 import 'package:civiconnect/user_management/user_management_dao.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:mockito/mockito.dart';
 
 /// Data Access Object (DAO) for managing citizen reports.
 class CitizenReportManagementDAO {
@@ -81,4 +82,37 @@ Future<List<Map<String, dynamic>>?> _getTenReportsByOffset({required String city
     return (user is Municipality && (user).municipalityName == city) || user is Citizen;
   }
 
+}
+
+
+/// Mock implementation of the `CitizenReportManagementDAO` class.
+class MockCitizenReportManagementDAO extends Mock implements CitizenReportManagementDAO {
+
+  @override
+  Future<List<Map<String, dynamic>>?> getReportList({required String city, DocumentSnapshot? lastDocument}) async {
+    Map<String, dynamic> report = {
+      'reportId': '123',
+      'uid': '456',
+      'title': 'Test Report',
+      'description': 'This is a test report',
+      'photo': 'test.jpg',
+      'address': {
+        'street': 'Main St',
+        'number': '123',
+      },
+      'location': const GeoPoint(0.0, 0.0),
+      'city': 'Test City',
+      'category': 'Illuminazione',
+      'status': 'In Lavorazione',
+      'authorFirstName': 'John',
+      'authorLastName': 'Doe',
+    };
+
+    List<Map<String, dynamic>> reports = [];
+    for(int i = 0; i < 10; i++) {
+      reports.add(report);
+    }
+
+    return Future.value(reports);
+  }
 }

--- a/src/lib/gestione_segnalazione_cittadino/gestione_segnalazione_cittadino_dao.dart
+++ b/src/lib/gestione_segnalazione_cittadino/gestione_segnalazione_cittadino_dao.dart
@@ -96,9 +96,20 @@ Future<List<Map<String, dynamic>>?> _getTenReportsByOffset({required String city
 
 /// Mock implementation of the `CitizenReportManagementDAO` class.
 class MockCitizenReportManagementDAO extends Mock implements CitizenReportManagementDAO {
+  /// The mock implementation of the `UserManagementDAO` class.
+  /// Could be passed in the constructor.
+  final UserManagementDAO userManagementDAO;
 
-  @override
-  Future<List<Map<String, dynamic>>?> getReportList({required String city, DocumentSnapshot? lastDocument}) async {
+  /// The mock list of reports.
+  late final List<Map<String, dynamic>> reports;
+
+  /// The index of the last document retrieved. MOCK
+  int _lastDocument = 0;
+
+  /// Constructs a new `MockCitizenReportManagementDAO` instance.
+  /// Parameters:
+  /// - [userManagementDAO]: An optional instance of `UserManagementDAO`. If not provided, a new instance of `UserManagementDAO` will be created.
+  MockCitizenReportManagementDAO({UserManagementDAO? userManagementDAO}) : userManagementDAO = userManagementDAO ?? UserManagementDAO(){
     Map<String, dynamic> report = {
       'reportId': '123',
       'uid': '456',
@@ -117,11 +128,28 @@ class MockCitizenReportManagementDAO extends Mock implements CitizenReportManage
       'authorLastName': 'Doe',
     };
 
-    List<Map<String, dynamic>> reports = [];
-    for(int i = 0; i < 10; i++) {
-      reports.add(report);
+    reports = [];
+    for(int i = 0; i < 30; i++) {
+      Map<String, dynamic> r = Map.from(report);
+      r['uid'] = i.toString();
+      reports.add(r);
     }
 
-    return Future.value(reports);
   }
+
+  @override
+  Future<List<Map<String, dynamic>>?> getReportList({required String city, DocumentSnapshot? lastDocument}) async {
+    if(_lastDocument == 0){
+      _lastDocument = 10;
+     return Future.value(reports.sublist(0, 10));
+    } else {
+      if(_lastDocument >= 30){
+        return Future.value(null);
+      }
+      int index = _lastDocument;
+      _lastDocument = index + 10;
+      return Future.value(reports.sublist(index, index + 10));
+    }
+  }
+
 }

--- a/src/lib/gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart
+++ b/src/lib/gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart
@@ -1,7 +1,10 @@
+import 'dart:math';
+
 import 'package:civiconnect/theme.dart';
 import 'package:civiconnect/utils/report_status_priority.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:hugeicons/hugeicons.dart';
 
 import '../widgets/card_widget.dart';
 import 'gestione_segnalazione_cittadino_controller.dart';
@@ -35,7 +38,7 @@ class _ReportsListCitizenState extends State<ReportsViewCitizenGUI> {
     _scrollController = ScrollController()
       ..addListener(() {
         if (_scrollController.position.pixels ==
-                _scrollController.position.maxScrollExtent &&
+            _scrollController.position.maxScrollExtent &&
             _hasMoreData &&
             !_isLoadingMore) {
           _loadUpdateData();
@@ -54,16 +57,17 @@ class _ReportsListCitizenState extends State<ReportsViewCitizenGUI> {
     if (_isLoading) {
       return _hasMoreData
           ? const Scaffold(
-              body: Center(child: CircularProgressIndicator()),
-            )
+        body: Center(child: CircularProgressIndicator()),
+      )
           : const Scaffold(
-              body: Center(child: Text('Fine.')),
-            );
+        body: Center(child: Text('Fine.')),
+      );
     }
 
     if (_userData.isEmpty) {
       return const Scaffold(
-        body: Center(child: Text('Nessun dato disponibile. Controlla la tua connessione.'),),
+        body: Center(child: Text(
+            'Nessun dato disponibile. Controlla la tua connessione.'),),
       );
     }
     return _buildScaffold();
@@ -165,11 +169,6 @@ class _ReportsListCitizenState extends State<ReportsViewCitizenGUI> {
                 child: _buildHeader(),
               ),
 
-              // Spacing Box
-              const SliverToBoxAdapter(
-                child: SizedBox(height: 20),
-              ),
-
               // Scrollable list
               _buildReportsList(),
             ],
@@ -185,11 +184,16 @@ class _ReportsListCitizenState extends State<ReportsViewCitizenGUI> {
       ),
     );
   }
+
   /// Builds the header of the page
   /// Contains the user profile picture and the search and filter buttons
-Widget _buildHeader() {
-  return Row(
+  Widget _buildHeader() {
+    return Row(
       children: [
+        /// Search bar
+        _searchBar(),
+
+        /// Filter button
         Padding(
           padding: const EdgeInsets.all(10.0),
           child: Card(
@@ -220,8 +224,8 @@ Widget _buildHeader() {
           ),
         )
       ],
-  );
-}
+    );
+  }
 
   /// Main Body of the page
   /// Contains the list of reports
@@ -229,33 +233,33 @@ Widget _buildHeader() {
     return SliverList(
       delegate: SliverChildBuilderDelegate(
         childCount: _userData.length + (_hasMoreData ? 1 : 0),
-        (context, index) {
+            (context, index) {
           if (index == _userData.length) {
             // Mostra un indicatore di caricamento alla fine della lista
             _loadUpdateData();
             return (_isLoading)
                 ? const Padding(
-                    padding: EdgeInsets.all(16.0),
-                    child: Center(child: CircularProgressIndicator()),
-                  )
+              padding: EdgeInsets.all(16.0),
+              child: Center(child: CircularProgressIndicator()),
+            )
                 : const SizedBox(height: 0);
           }
           final report = _userData[index];
           return (_errorText != '')
               ? Text(_errorText)
               : CardWidget(
-                  uid: report['uid'],
-                  name: '${report['authorFirstName']} ${report['uid']}',
-                  description: report['title'],
-                  status: StatusReport.getStatus(report['status']) ??
-                      StatusReport.rejected,
-                  priority: PriorityReport.getPriority(report['priority']) ??
-                      PriorityReport.unset,
-                  imageUrl: '',
-                  onTap: () {
-                    // TODO: vai alla pagina dei dettagli
-                  },
-                );
+            uid: report['uid'],
+            name: '${report['authorFirstName']} ${report['uid']}',
+            description: report['title'],
+            status: StatusReport.getStatus(report['status']) ??
+                StatusReport.rejected,
+            priority: PriorityReport.getPriority(report['priority']) ??
+                PriorityReport.unset,
+            imageUrl: '',
+            onTap: () {
+              // TODO: vai alla pagina dei dettagli
+            },
+          );
         },
       ),
     );
@@ -268,4 +272,59 @@ Widget _buildHeader() {
     _loadInitialData();
     await Future.delayed(const Duration(seconds: 1));
   }
+
+
+  /// Builds the search bar
+  /// /// Builds the search bar widget.
+  ///
+  /// This widget contains a search icon and a text field for searching reports.
+  /// The search icon does not have any functionality implemented yet.
+  Widget _searchBar() {
+    return Padding(
+      padding: const EdgeInsets.all(10.0),
+      child: Card(
+        color: Colors.white70,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12),
+        ),
+        elevation: 2,
+        shadowColor: Colors.black.withOpacity(0.5),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 5, horizontal: 5),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.start,
+            children: [
+              IconButton(
+                icon: Icon(
+                  HugeIcons.strokeRoundedSearch02,
+                  size: 24,
+                  color: theme.colorScheme.onPrimaryContainer,
+                ),
+                onPressed: () { // TODO - Implement search functionality
+                },
+              ),
+              SizedBox(
+                width: max(MediaQuery.of(context).size.width * 0.5, 200),
+                child: const TextField(
+                  decoration: InputDecoration(
+                      fillColor: Colors.white,
+                      filled: true,
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.all(Radius.circular(12)),
+                        borderSide: BorderSide.none,
+                      ),
+                      hintText: 'Cerca segnalazione...'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+
+
+
 }

--- a/src/lib/gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart
+++ b/src/lib/gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart
@@ -66,8 +66,10 @@ class _ReportsListCitizenState extends State<ReportsViewCitizenGUI> {
 
     if (_userData.isEmpty) {
       return const Scaffold(
-        body: Center(child: Text(
-            'Nessun dato disponibile. Controlla la tua connessione.'),),
+        body: Center(
+          child: Text(
+            'Nessun dato disponibile. Controlla la tua connessione.'),
+        ),
       );
     }
     return _buildScaffold();
@@ -78,32 +80,32 @@ class _ReportsListCitizenState extends State<ReportsViewCitizenGUI> {
   /// This method fetches the current citizen user and their reports,
   /// and updates the state with the retrieved data.
   Future<void> _loadInitialData() async {
-    setState(() {
-      _isLoading = true;
-      _hasMoreData = true;
-    });
-
+      setState(() {
+        _isLoading = true;
+        _hasMoreData = true;
+      });
     try {
       _reportController.citizen.then((value) {
         _reportController.getUserReports(reset: true).then((value) {
+          _userData.clear();
           setState(() {
-            _userData.clear();
             if (value != null && value.isNotEmpty) {
               _userData.addAll(value);
             } else {
               _hasMoreData = false;
             }
+            _isLoading = false;
           });
         });
       });
     } catch (e) {
       _errorText = 'Errore durante il caricamento iniziale: $e';
-    } finally {
       setState(() {
         _isLoading = false;
       });
     }
   }
+
 
   /// Loads additional data when the user scrolls to the bottom of the list.
   ///
@@ -249,7 +251,7 @@ class _ReportsListCitizenState extends State<ReportsViewCitizenGUI> {
               ? Text(_errorText)
               : CardWidget(
             uid: report['uid'],
-            name: '${report['authorFirstName']} ${report['uid']}',
+            name: '${report['authorFirstName']} ${report['authorLastName']}',
             description: report['title'],
             status: StatusReport.getStatus(report['status']) ??
                 StatusReport.rejected,

--- a/src/lib/gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart
+++ b/src/lib/gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart
@@ -153,6 +153,7 @@ class _ReportsListCitizenState extends State<ReportsViewCitizenGUI> {
       itemBuilder: (context, index) {
         final report = reports?[index];
         return CardWidget(
+          uid: report?['uid'],
           name: report?['authorFirstName'] + ' ' + report?['authorLastName'],
           description: report?['title'],
           status: StatusReport.getStatus(report?['status']) ?? StatusReport.rejected,

--- a/src/lib/gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart
+++ b/src/lib/gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart
@@ -2,7 +2,6 @@ import 'package:civiconnect/model/users_model.dart';
 import 'package:civiconnect/theme.dart';
 import 'package:civiconnect/utils/report_status_priority.dart';
 import 'package:flutter/material.dart';
-import 'package:hugeicons/hugeicons.dart';
 
 import '../widgets/card_widget.dart';
 import 'gestione_segnalazione_cittadino_controller.dart';

--- a/src/lib/gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart
+++ b/src/lib/gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart
@@ -78,7 +78,6 @@ class _ReportsListCitizenState extends State<ReportsViewCitizenGUI> {
           child: Column(
             children: [
               _buildHeader(),
-              const SizedBox(height: 20),
               _buildReportsList(userData),
             ],
           ),
@@ -94,56 +93,41 @@ class _ReportsListCitizenState extends State<ReportsViewCitizenGUI> {
     );
   }
 
-  Widget _buildHeader() {
-    return Padding(
-      padding: const EdgeInsets.all(16.0),
-      child: Container(
-        decoration: BoxDecoration(
-          color: theme.colorScheme.surface,
-          borderRadius: BorderRadius.circular(12),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withOpacity(0.1),
-              spreadRadius: 2,
-              blurRadius: 5,
-              offset: const Offset(0, 3),
+Widget _buildHeader() {
+  return Row(
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(10.0),
+          child: Card(
+            color: Colors.white70,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
             ),
-          ],
-        ),
-        child: Padding(
-          padding: EdgeInsets.symmetric(
-              vertical: 10, horizontal: MediaQuery.of(context).size.width / 10),
-          child: Row(
-            children: [
-              CircleAvatar(
-                radius: 20,
-                backgroundImage: userInfo != null ? AssetImage('assets/images/profile/${userInfo!.uid.hashCode % 6}.jpg') : const AssetImage('assets/images/profile/0.jpg'),
+            elevation: 2,
+            shadowColor: Colors.black.withOpacity(0.5),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 5, horizontal: 5),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                mainAxisAlignment: MainAxisAlignment.start,
+                children: [
+                  IconButton(
+                    icon: Icon(
+                      Icons.filter_list,
+                      color: theme.colorScheme.onPrimaryContainer,
+                    ),
+                    onPressed: () {
+                      // TODO: Implementa il metodo di selezione del filtro
+                    },
+                  ),
+                ],
               ),
-              const SizedBox(width: 12),
-              Text('Benvenuto', style: textStyle),
-              const Expanded(child: UnconstrainedBox()),
-              IconButton(
-                onPressed: () {},
-                icon: HugeIcon(
-                  icon: HugeIcons.strokeRoundedSearch01,
-                  color: theme.colorScheme.onPrimaryContainer,
-                ),
-              ),
-              IconButton(
-                icon: Icon(
-                  Icons.filter_list,
-                  color: theme.colorScheme.onPrimaryContainer,
-                ),
-                onPressed: () {
-                  // TODO: Implementa il metodo di selezione del filtro
-                },
-              ),
-            ],
+            ),
           ),
-        ),
-      ),
-    );
-  }
+        )
+      ],
+  );
+}
 
   Widget _buildReportsList(List<Map<String, dynamic>> userData) {
     return ListView.builder(

--- a/src/lib/gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart
+++ b/src/lib/gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart
@@ -5,15 +5,15 @@ import 'package:hugeicons/hugeicons.dart';
 import '../model/users_model.dart';
 
 /// Gui to visualize reports list of citizen city
-class ReportsListCitizenGUI extends StatefulWidget {
-  /// Constructor of [ReportsListCitizenGUI]
-  const ReportsListCitizenGUI({super.key});
+class ReportsViewCitizenGUI extends StatefulWidget {
+  /// Constructor of [ReportsViewCitizenGUI]
+  const ReportsViewCitizenGUI({super.key});
 
   @override
-  State<ReportsListCitizenGUI> createState() => _ReportsListCitizenState();
+  State<ReportsViewCitizenGUI> createState() => _ReportsListCitizenState();
 }
 
-class _ReportsListCitizenState extends State<ReportsListCitizenGUI> {
+class _ReportsListCitizenState extends State<ReportsViewCitizenGUI> {
 
   // Variable State
   bool isEditing = false;

--- a/src/lib/gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart
+++ b/src/lib/gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart
@@ -1,0 +1,76 @@
+import 'package:civiconnect/theme.dart';
+import 'package:flutter/material.dart';
+import 'package:hugeicons/hugeicons.dart';
+
+import '../model/users_model.dart';
+
+/// Gui to visualize reports list of citizen city
+class ReportsListCitizenGUI extends StatefulWidget {
+  /// Constructor of [ReportsListCitizenGUI]
+  const ReportsListCitizenGUI({super.key});
+
+  @override
+  State<ReportsListCitizenGUI> createState() => _ReportsListCitizenState();
+}
+
+class _ReportsListCitizenState extends State<ReportsListCitizenGUI> {
+
+  // Variable State
+  bool isEditing = false;
+  Map<String, dynamic> userData = {};
+  bool isLoading = true; // If data are loading
+  late ThemeData theme;
+  late TextStyle textStyle;
+  late GenericUser userInfo;
+
+  @override
+  void initState() {
+    super.initState();
+    theme = ThemeManager().customTheme;
+    textStyle = theme.textTheme.titleMedium!.copyWith(fontSize: 16);
+    _loadUpdate();
+  }
+
+   void _loadUpdate(){
+    setState(() {
+      isLoading = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (isLoading) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    return SafeArea(
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Padding(
+                  padding: EdgeInsets.symmetric(vertical: 10, horizontal: MediaQuery.of(context).size.width / 10),
+                  child: Row(
+                    children: [
+                      Text('Benvenuto', style: Theme.of(context).textTheme.titleMedium),
+                      const Expanded(child: UnconstrainedBox()),
+                      IconButton(onPressed: (){}, icon: HugeIcon(icon: HugeIcons.strokeRoundedSearch01, color: Theme.of(context).colorScheme.onPrimaryContainer))
+                    ],
+                  ),
+                )
+              ],
+            ),
+          ),
+        ),
+    );
+  }
+
+
+
+
+
+}

--- a/src/lib/gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart
+++ b/src/lib/gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart
@@ -1,9 +1,7 @@
-import 'package:civiconnect/model/users_model.dart';
 import 'package:civiconnect/theme.dart';
 import 'package:civiconnect/utils/report_status_priority.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
-import 'package:hugeicons/hugeicons.dart';
 
 import '../widgets/card_widget.dart';
 import 'gestione_segnalazione_cittadino_controller.dart';
@@ -20,8 +18,6 @@ class ReportsViewCitizenGUI extends StatefulWidget {
 class _ReportsListCitizenState extends State<ReportsViewCitizenGUI> {
   late final CitizenReportManagementController _reportController;
   late final ThemeData theme;
-  late final TextStyle _textStyle;
-  GenericUser? _userInfo;
   late final List<Map<String, dynamic>> _userData = [];
   bool _isLoadingMore = false;
   bool _hasMoreData = true;
@@ -35,7 +31,6 @@ class _ReportsListCitizenState extends State<ReportsViewCitizenGUI> {
   /// and loads the initial data.
   @override
   void initState() {
-    _userInfo = null;
     super.initState();
     _scrollController = ScrollController()
       ..addListener(() {
@@ -48,7 +43,6 @@ class _ReportsListCitizenState extends State<ReportsViewCitizenGUI> {
       });
     _reportController = CitizenReportManagementController();
     theme = ThemeManager().customTheme;
-    _textStyle = theme.textTheme.titleMedium!.copyWith(fontSize: 16);
     _loadInitialData(); // Load initial data
   }
 
@@ -85,7 +79,6 @@ class _ReportsListCitizenState extends State<ReportsViewCitizenGUI> {
       _hasMoreData = true;
     });
     try {
-      _userInfo = await _reportController.citizen;
       final newData = await _reportController.getUserReports();
       setState(() {
         _userData.clear();

--- a/src/lib/gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart
+++ b/src/lib/gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart
@@ -29,6 +29,10 @@ class _ReportsListCitizenState extends State<ReportsViewCitizenGUI> {
   String _errorText = '';
   late ScrollController _scrollController;
 
+  /// Initializes the state of the widget.
+  ///
+  /// This method sets up the scroll controller, initializes the report controller,
+  /// and loads the initial data.
   @override
   void initState() {
     _userInfo = null;
@@ -71,6 +75,10 @@ class _ReportsListCitizenState extends State<ReportsViewCitizenGUI> {
     return _buildScaffold();
   }
 
+  /// Loads the initial data for the widget.
+  ///
+  /// This method fetches the current citizen user and their reports,
+  /// and updates the state with the retrieved data.
   Future<void> _loadInitialData() async {
     setState(() {
       _isLoading = true;
@@ -96,6 +104,10 @@ class _ReportsListCitizenState extends State<ReportsViewCitizenGUI> {
     }
   }
 
+  /// Loads additional data when the user scrolls to the bottom of the list.
+  ///
+  /// This method fetches more reports from the controller and updates the state
+  /// with the new data.
   void _loadUpdateData() {
     SchedulerBinding.instance.addPostFrameCallback((_) async {
       setState(() {
@@ -252,8 +264,9 @@ Widget _buildHeader() {
     );
   }
 
-  /// Refresh the data
-  /// Wait 1 second before refresh
+  /// Refreshes the data when the user performs a pull-to-refresh action.
+  ///
+  /// This method reloads the initial data and waits for a short delay before completing.
   Future<void> _pullRefresh() async {
     _loadInitialData();
     await Future.delayed(const Duration(seconds: 1));

--- a/src/lib/gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart
+++ b/src/lib/gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart
@@ -63,7 +63,7 @@ class _ReportsListCitizenState extends State<ReportsViewCitizenGUI> {
 
     if (_userData.isEmpty) {
       return const Scaffold(
-        body: Center(child: Text('Nessun dato utente disponibile.')),
+        body: Center(child: Text('Nessun dato disponibile. Controlla la tua connessione.'),),
       );
     }
     return _buildScaffold();
@@ -78,18 +78,22 @@ class _ReportsListCitizenState extends State<ReportsViewCitizenGUI> {
       _isLoading = true;
       _hasMoreData = true;
     });
+
     try {
-      final newData = await _reportController.getUserReports();
-      setState(() {
-        _userData.clear();
-        if (newData != null && newData.isNotEmpty) {
-          _userData.addAll(newData);
-        } else {
-          _hasMoreData = false;
-        }
+      _reportController.citizen.then((value) {
+        _reportController.getUserReports().then((value) {
+          setState(() {
+            _userData.clear();
+            if (value != null && value.isNotEmpty) {
+              _userData.addAll(value);
+            } else {
+              _hasMoreData = false;
+            }
+          });
+        });
       });
     } catch (e) {
-      _errorText = 'Errore durante il caricamento iniziale';
+      _errorText = 'Errore durante il caricamento iniziale: $e';
     } finally {
       setState(() {
         _isLoading = false;

--- a/src/lib/gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart
+++ b/src/lib/gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart
@@ -81,7 +81,7 @@ class _ReportsListCitizenState extends State<ReportsViewCitizenGUI> {
 
     try {
       _reportController.citizen.then((value) {
-        _reportController.getUserReports().then((value) {
+        _reportController.getUserReports(reset: true).then((value) {
           setState(() {
             _userData.clear();
             if (value != null && value.isNotEmpty) {

--- a/src/lib/gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart
+++ b/src/lib/gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart
@@ -1,8 +1,13 @@
 import 'package:civiconnect/theme.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:hugeicons/hugeicons.dart';
 
 import '../model/users_model.dart';
+import '../user_management/user_management_controller.dart';
+import '../user_management/user_management_dao.dart';
+import '../widgets/card_widget.dart';
+import 'gestione_segnalazione_cittadino_controller.dart';
 
 /// Gui to visualize reports list of citizen city
 class ReportsViewCitizenGUI extends StatefulWidget {
@@ -22,6 +27,7 @@ class _ReportsListCitizenState extends State<ReportsViewCitizenGUI> {
   late ThemeData theme;
   late TextStyle textStyle;
   late GenericUser userInfo;
+  late UserManagementController userController;
 
   @override
   void initState() {
@@ -31,7 +37,27 @@ class _ReportsListCitizenState extends State<ReportsViewCitizenGUI> {
     _loadUpdate();
   }
 
-   void _loadUpdate(){
+  void _loadUpdate() async {
+    userInfo = (await UserManagementDAO().determineUserType())!;
+    /*late Map<String, dynamic> data;
+    try {
+      userInfo = (await UserManagementDAO().determineUserType())!;
+      if (userInfo is Citizen) {
+        data = await userController.getUserData();
+      } else {
+        setState(() {
+          isLoading = false;
+        });
+      }
+      setState(() {
+        userData = data;
+        isLoading = false;
+      });
+    } catch (e) {
+      setState(() {
+        isLoading = false;
+      });
+    } */
     setState(() {
       isLoading = false;
     });
@@ -45,31 +71,109 @@ class _ReportsListCitizenState extends State<ReportsViewCitizenGUI> {
       );
     }
 
-    return SafeArea(
-        child: SingleChildScrollView(
-          child: Padding(
-            padding: const EdgeInsets.all(16.0),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                Padding(
-                  padding: EdgeInsets.symmetric(vertical: 10, horizontal: MediaQuery.of(context).size.width / 10),
-                  child: Row(
-                    children: [
-                      Text('Benvenuto', style: Theme.of(context).textTheme.titleMedium),
-                      const Expanded(child: UnconstrainedBox()),
-                      IconButton(onPressed: (){}, icon: HugeIcon(icon: HugeIcons.strokeRoundedSearch01, color: Theme.of(context).colorScheme.onPrimaryContainer))
+    return Scaffold(
+        body: SingleChildScrollView(
+          child: Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).colorScheme.surface,
+                    borderRadius: BorderRadius.circular(12),
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withOpacity(0.1),
+                        spreadRadius: 2,
+                        blurRadius: 5,
+                        offset: const Offset(0, 3),
+                      ),
                     ],
                   ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      Padding(
+                        padding: EdgeInsets.symmetric(vertical: 10, horizontal: MediaQuery.of(context).size.width / 10),
+                        child: Row(
+                          children: [
+                            CircleAvatar(
+                                radius: 20,
+                                backgroundImage: AssetImage('assets/images/profile/${userInfo.uid.hashCode % 6}.jpg')
+                            ),
+                            const SizedBox(width: 12),
+                            Text('Benvenuto', style: Theme.of(context).textTheme.titleMedium),
+                            const Expanded(child: UnconstrainedBox()),
+                            IconButton(onPressed: (){}, icon: HugeIcon(icon: HugeIcons.strokeRoundedSearch01, color: Theme.of(context).colorScheme.onPrimaryContainer))
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 20),
+              IconButton(
+                alignment: Alignment.topLeft,
+                icon: Icon(Icons.filter_list_alt, color: Theme.of(context).colorScheme.onPrimaryContainer),
+                onPressed: () {
+                  // TODO: Implement filter selection method
+                },
+              ),
+              const SizedBox(height: 20),
+              const SizedBox(height: 20),
+              // [ReportsList
+              if (userData.isNotEmpty)
+                FutureBuilder<Widget>(
+                  future: _buildReportsList(),
+                  builder: (context, snapshot) {
+                    if (snapshot.connectionState == ConnectionState.waiting) {
+                      return const CircularProgressIndicator();
+                    } else if (snapshot.hasError) {
+                      return const Text('Errore nel caricamento delle segnalazioni.');
+                    } else {
+                      return snapshot.data!;
+                    }
+                  },
                 )
-              ],
-            ),
-          ),
+              else
+                  const Text('Nessun dato utente disponibile.')
+            ],
+          )
         ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          // TODO: Implement action for the button
+        },
+        backgroundColor: theme.colorScheme.primary,
+        child: Icon(Icons.add, color: theme.colorScheme.onPrimary),
+      ),
     );
   }
 
+  Future<Widget> _buildReportsList() async {
+    // Example data, replace with actual data fetching logic
+    final reports = await CitizenReportManagementController().getUserReports(userInfo as Citizen);
 
+    return ListView.builder(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      itemCount: reports.length,
+      itemBuilder: (context, index) {
+        final report = reports[index];
+        return CardWidget(
+          name: report['name'],
+          description: report['title'],
+          status: report['status'],
+          priority: report['priority'],
+          imageUrl: '',
+          onTap: () {
+            // Handle card tap
+          },
+        );
+      },
+    );
+  }
 
 
 

--- a/src/lib/home_page.dart
+++ b/src/lib/home_page.dart
@@ -17,7 +17,7 @@ class _HomePageState extends State<HomePage> {
 
   final List<Widget> _pages = <Widget>[
     const Placeholder(),
-    const ReportsListCitizenGUI(),
+    const ReportsViewCitizenGUI(),
     const UserProfile(),
   ];
 

--- a/src/lib/home_page.dart
+++ b/src/lib/home_page.dart
@@ -1,6 +1,8 @@
 import 'package:civiconnect/user_management/user_profile_gui.dart';
 import 'package:flutter/material.dart';
 
+import 'gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart';
+
 /// Home page of the application.
 class HomePage extends StatefulWidget {
   /// Home page of the application.
@@ -15,7 +17,7 @@ class _HomePageState extends State<HomePage> {
 
   final List<Widget> _pages = <Widget>[
     const Placeholder(),
-    const Placeholder(),
+    const ReportsListCitizenGUI(),
     const UserProfile(),
   ];
 

--- a/src/lib/home_page.dart
+++ b/src/lib/home_page.dart
@@ -17,7 +17,7 @@ class HomePage extends StatefulWidget {
 
 class _HomePageState extends State<HomePage> {
   int _selectedIndex = 1;
-  late GenericUser userInfo;
+  GenericUser? userInfo;
   bool isLoading = false;
   Map<String, dynamic> userData = {};
   late UserManagementController userController;
@@ -124,9 +124,9 @@ class _HomePageState extends State<HomePage> {
                 children: [
                   CircleAvatar(
                     radius: 20,
-                    backgroundImage: AssetImage(
-                      'assets/images/profile/${userInfo.uid.hashCode % 6}.jpg',
-                    ),
+                    backgroundImage: userInfo != null ? AssetImage(
+                      'assets/images/profile/${userInfo!.uid.hashCode % 6}.jpg',
+                    ) : const AssetImage('assets/images/profile/0.jpg' ),
                   ),
                   const SizedBox(width: 12),
                   Text(userInfo is Citizen ? '${userData['firstName']} ${userData['lastName']}' : userData['municipalityName'], style: TextStyle(color: Theme.of(context).colorScheme.onPrimary)),

--- a/src/lib/home_page.dart
+++ b/src/lib/home_page.dart
@@ -129,7 +129,7 @@ class _HomePageState extends State<HomePage> {
                     ),
                   ),
                   const SizedBox(width: 12),
-                  Text('${userData['firstName']} ${userData['lastName']}', style: TextStyle(color: Theme.of(context).colorScheme.onPrimary)),
+                  Text(userInfo is Citizen ? '${userData['firstName']} ${userData['lastName']}' : userData['municipalityName'], style: TextStyle(color: Theme.of(context).colorScheme.onPrimary)),
                   const Expanded(child: UnconstrainedBox()),
                   IconButton(
                     alignment: Alignment.topLeft,

--- a/src/lib/home_page.dart
+++ b/src/lib/home_page.dart
@@ -1,7 +1,10 @@
+import 'package:civiconnect/user_management/user_management_controller.dart';
+import 'package:civiconnect/user_management/user_management_dao.dart';
 import 'package:civiconnect/user_management/user_profile_gui.dart';
 import 'package:flutter/material.dart';
 
 import 'gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart';
+import 'model/users_model.dart';
 
 /// Home page of the application.
 class HomePage extends StatefulWidget {
@@ -14,17 +17,42 @@ class HomePage extends StatefulWidget {
 
 class _HomePageState extends State<HomePage> {
   int _selectedIndex = 1;
+  late GenericUser userInfo;
+  bool isLoading = false;
+  Map<String, dynamic> userData = {};
+  late UserManagementController userController;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadUserData();
+  }
+
+  void _loadUserData() async {
+    userController = UserManagementController(redirectPage: const HomePage());
+    late Map<String, dynamic> data;
+    try {
+      userInfo = (await UserManagementDAO().determineUserType())!;
+      if (userInfo is Citizen) {
+        data = await userController.getUserData();
+      } else {
+        data = await userController.getMunicipalityData();
+      }
+      setState(() {
+        userData = data;
+        isLoading = false;
+      });
+    } catch (e) {
+      setState(() {
+        isLoading = false;
+      });
+    }
+  }
 
   final List<Widget> _pages = <Widget>[
     const Placeholder(),
     const ReportsViewCitizenGUI(),
     const UserProfile(),
-  ];
-
-  final List<String> _title = [
-    'Segnalazioni',
-    'Home',
-    'Area Personale',
   ];
 
   void _onItemTapped(int index) {
@@ -35,10 +63,13 @@ class _HomePageState extends State<HomePage> {
 
   @override
   Widget build(BuildContext context) {
+    if (isLoading) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
     return Scaffold(
-      appBar: AppBar(
-        title: Text(_title[_selectedIndex]),
-      ),
+      appBar: _buildAppBar(),
       body: _pages[_selectedIndex],
       bottomNavigationBar: BottomNavigationBar(
         items: const [
@@ -60,5 +91,61 @@ class _HomePageState extends State<HomePage> {
       ),
     );
     //return const TestingPage();
+  }
+
+  PreferredSizeWidget _buildAppBar() {
+    if (_selectedIndex == 2) {
+      return
+        AppBar(
+          title: Text('Area Utente', style: TextStyle(color: Theme.of(context).colorScheme.onPrimary)),
+          shape: const RoundedRectangleBorder(
+            borderRadius: BorderRadius.vertical(
+              bottom: Radius.circular(15),
+            ),
+          ),
+          elevation: 10,
+          shadowColor: Theme.of(context).shadowColor.withOpacity(0.9),
+        );
+    }
+    return PreferredSize(
+      preferredSize: const Size.fromHeight(75),
+      child: AppBar(
+          shape: const RoundedRectangleBorder(
+            borderRadius: BorderRadius.vertical(
+              bottom: Radius.circular(15),
+            ),
+          ),
+          elevation: 10,
+          shadowColor: Theme.of(context).shadowColor.withOpacity(0.9),
+          title: Column(
+            children: [
+              const SizedBox(height: 20),
+              Row(
+                children: [
+                  CircleAvatar(
+                    radius: 20,
+                    backgroundImage: AssetImage(
+                      'assets/images/profile/${userInfo.uid.hashCode % 6}.jpg',
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Text('${userData['firstName']} ${userData['lastName']}', style: TextStyle(color: Theme.of(context).colorScheme.onPrimary)),
+                  const Expanded(child: UnconstrainedBox()),
+                  IconButton(
+                    alignment: Alignment.topLeft,
+                    icon: Icon(
+                      Icons.accessible_forward_sharp,
+                      color: Theme.of(context).colorScheme.onPrimary,
+                    ),
+                    onPressed: () {
+                      // TODO: Implement filter selection method
+                    },
+                  ),
+                ],
+              ),
+            ],
+          )
+      )
+    );
   }
 }

--- a/src/lib/home_page.dart
+++ b/src/lib/home_page.dart
@@ -95,57 +95,65 @@ class _HomePageState extends State<HomePage> {
 
   PreferredSizeWidget _buildAppBar() {
     if (_selectedIndex == 2) {
-      return
-        AppBar(
-          title: Text('Area Utente', style: TextStyle(color: Theme.of(context).colorScheme.onPrimary)),
-          shape: const RoundedRectangleBorder(
-            borderRadius: BorderRadius.vertical(
-              bottom: Radius.circular(15),
-            ),
+      return AppBar(
+        title: Text('Area Utente',
+            style: TextStyle(color: Theme.of(context).colorScheme.onPrimary)),
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.vertical(
+            bottom: Radius.circular(15),
           ),
-          elevation: 10,
-          shadowColor: Theme.of(context).shadowColor.withOpacity(0.9),
-        );
+        ),
+        elevation: 10,
+        shadowColor: Theme.of(context).shadowColor.withOpacity(0.9),
+      );
     }
     return PreferredSize(
-      preferredSize: const Size.fromHeight(75),
-      child: AppBar(
-          shape: const RoundedRectangleBorder(
-            borderRadius: BorderRadius.vertical(
-              bottom: Radius.circular(15),
-            ),
-          ),
-          elevation: 10,
-          shadowColor: Theme.of(context).shadowColor.withOpacity(0.9),
-          title: Column(
-            children: [
-              const SizedBox(height: 20),
-              Row(
-                children: [
-                  CircleAvatar(
-                    radius: 20,
-                    backgroundImage: userInfo != null ? AssetImage(
-                      'assets/images/profile/${userInfo!.uid.hashCode % 6}.jpg',
-                    ) : const AssetImage('assets/images/profile/0.jpg' ),
-                  ),
-                  const SizedBox(width: 12),
-                  Text(userInfo is Citizen ? '${userData['firstName']} ${userData['lastName']}' : userData['municipalityName'], style: TextStyle(color: Theme.of(context).colorScheme.onPrimary)),
-                  const Expanded(child: UnconstrainedBox()),
-                  IconButton(
-                    alignment: Alignment.topLeft,
-                    icon: Icon(
-                      Icons.accessible_forward_sharp,
-                      color: Theme.of(context).colorScheme.onPrimary,
-                    ),
-                    onPressed: () {
-                      // TODO: Implement filter selection method
-                    },
-                  ),
-                ],
+        preferredSize: const Size.fromHeight(75),
+        child: AppBar(
+            shape: const RoundedRectangleBorder(
+              borderRadius: BorderRadius.vertical(
+                bottom: Radius.circular(15),
               ),
-            ],
-          )
-      )
-    );
+            ),
+            elevation: 10,
+            shadowColor: Theme.of(context).shadowColor.withOpacity(0.9),
+            title: Column(
+              children: [
+                const SizedBox(height: 20),
+                Row(
+                  children: [
+                    CircleAvatar(
+                      radius: 20,
+                      backgroundImage: userInfo != null
+                          ? AssetImage(
+                              'assets/images/profile/${userInfo!.uid.hashCode % 6}.jpg',
+                            )
+                          : const AssetImage('assets/images/profile/0.jpg'),
+                    ),
+                    const SizedBox(width: 12),
+                    userInfo != null
+                        ? Text(
+                            userInfo is Citizen
+                                ? '${userData['firstName']} ${userData['lastName']}'
+                                : userData['municipalityName'],
+                            style: TextStyle(
+                                color: Theme.of(context).colorScheme.onPrimary))
+                        : const Text('Benvenuto Utente',
+                            style: TextStyle(color: Colors.white)),
+                    const Expanded(child: UnconstrainedBox()),
+                    IconButton(
+                      alignment: Alignment.topLeft,
+                      icon: Icon(
+                        Icons.accessible_forward_sharp,
+                        color: Theme.of(context).colorScheme.onPrimary,
+                      ),
+                      onPressed: () {
+                        // TODO: Implement filter selection method
+                      },
+                    ),
+                  ],
+                ),
+              ],
+            )));
   }
 }

--- a/src/lib/model/report_model.dart
+++ b/src/lib/model/report_model.dart
@@ -26,6 +26,16 @@ enum Category {
 
   /// Returns the name of the category.
   String name() => _name;
+
+  /// Returns the category based on the [name].
+  static Category? getCategory(String name) {
+    for(Category category in Category.values) {
+      if(category.name() == name) {
+        return category;
+      }
+    }
+    return null;
+  }
 }
 
 

--- a/src/lib/utils/report_status_priority.dart
+++ b/src/lib/utils/report_status_priority.dart
@@ -60,6 +60,9 @@ enum StatusReport implements Comparable<StatusReport> {
 /// This enum categorizes the priority levels of a report. Each priority level
 /// has a [name], [value], and a [color] associated with it for visual representation.
 enum PriorityReport implements Comparable<PriorityReport> {
+  /// Unset priority level.
+  unset(value: -1, name: 'Non impostata', color: Colors.grey),
+
   /// Low priority level.
   low(value: 0, name: 'Bassa', color: Colors.yellow),
 

--- a/src/lib/utils/report_status_priority.dart
+++ b/src/lib/utils/report_status_priority.dart
@@ -45,7 +45,7 @@ enum StatusReport implements Comparable<StatusReport> {
   int compareTo(StatusReport other) => value - other.value;
 
   /// Returns the status of the report based on the [name].
-  static StatusReport? getStatus(String name) {
+  static StatusReport? getStatus(String? name) {
     for(StatusReport status in StatusReport.values) {
       if(status.name() == name) {
         return status;
@@ -103,7 +103,7 @@ enum PriorityReport implements Comparable<PriorityReport> {
   String get name => _name;
 
   /// Returns the priority of the report based on the [name].
-  static PriorityReport? getPriority(String name) {
+  static PriorityReport? getPriority(String? name) {
     for(PriorityReport priority in PriorityReport.values) {
       if(priority.name == name) {
         return priority;

--- a/src/lib/utils/report_status_priority.dart
+++ b/src/lib/utils/report_status_priority.dart
@@ -12,7 +12,7 @@ enum StatusReport implements Comparable<StatusReport> {
   accepted(name: 'Accettata', value: 1),
 
   /// The report is being worked on to resolve the issue.
-  inProgress(name: 'In lavorazione', value: 2),
+  inProgress(name: 'In Lavorazione', value: 2),
 
   /// The report has been completed.
   completed(name: 'Completata', value: 3),
@@ -43,6 +43,16 @@ enum StatusReport implements Comparable<StatusReport> {
 
   @override
   int compareTo(StatusReport other) => value - other.value;
+
+  /// Returns the status of the report based on the [name].
+  static StatusReport? getStatus(String name) {
+    for(StatusReport status in StatusReport.values) {
+      if(status.name() == name) {
+        return status;
+      }
+    }
+    return null;
+  }
 }
 
 /// Represents the priority of a report.
@@ -88,6 +98,16 @@ enum PriorityReport implements Comparable<PriorityReport> {
   ///
   /// This can be used for display purposes.
   String get name => _name;
+
+  /// Returns the priority of the report based on the [name].
+  static PriorityReport? getPriority(String name) {
+    for(PriorityReport priority in PriorityReport.values) {
+      if(priority.name == name) {
+        return priority;
+      }
+    }
+    return null;
+  }
 
   @override
   int compareTo(PriorityReport other) => _value - other.value;

--- a/src/lib/widgets/card_widget.dart
+++ b/src/lib/widgets/card_widget.dart
@@ -12,6 +12,7 @@ class CardWidget extends StatelessWidget {
   /// The [name], [description], [status], [priority], and [imageUrl] parameters are required.
   /// The [onTap] is optional.
   const CardWidget({
+    required this.uid,
     required this.name,
     required this.description,
     required this.status,
@@ -20,6 +21,9 @@ class CardWidget extends StatelessWidget {
     this.onTap,
     super.key,
   });
+
+  /// The unique identifier of the user.
+  final String uid;
 
   /// The name displayed on the card.
   final String name;
@@ -39,12 +43,13 @@ class CardWidget extends StatelessWidget {
   /// Callback triggered when the card is tapped.
   final void Function()? onTap;
 
+
   @override
   Widget build(BuildContext context) {
     TextTheme textTheme = Theme.of(context).textTheme;
 
     return Padding(
-      padding: const EdgeInsets.all(15.0),
+      padding: const EdgeInsets.all(10.0),
       child: GestureDetector(
         onTap: onTap,
         child: Card(
@@ -60,7 +65,10 @@ class CardWidget extends StatelessWidget {
                     children: [
                       Row(
                         children: [
-                          const Icon(Icons.account_circle, size: 50),
+                          CircleAvatar(
+                            radius: 20,
+                            backgroundImage: AssetImage('assets/images/profile/${uid.hashCode % 6}.jpg'),
+                          ),
                           const SizedBox(width: 10),
                           Expanded(
                             child: Text(
@@ -72,8 +80,6 @@ class CardWidget extends StatelessWidget {
                         ],
                       ),
                       const SizedBox(height: 10),
-                      _StatusReport(status: status, priority: priority),
-                      const SizedBox(height: 10),
                       Padding(
                         padding: const EdgeInsets.all(8.0),
                         child: Text(
@@ -83,6 +89,8 @@ class CardWidget extends StatelessWidget {
                           maxLines: 2,
                         ),
                       ),
+                      const SizedBox(height: 15),
+                      _StatusReport(status: status, priority: priority),
                     ],
                   ),
                 ),
@@ -144,31 +152,42 @@ class _StatusReport extends StatelessWidget {
 
     return Row(
       children: [
-        SizedBox(
-          width: MediaQuery.of(context).size.width * 0.65 * 0.65,
-          child: Text(
-            status.name(),
-            style: textTheme.bodySmall,
-            textAlign: TextAlign.center,
+        Card(
+          elevation: 0.5,
+          color: Colors.white70,
+          child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 10.0, vertical: 7.0),
+              child: Row(
+                children: [
+                  CircleAvatar(
+                    radius: 6,
+                    backgroundColor: Colors.black26,
+                    child: CircleAvatar(
+                      radius: 5,
+                      backgroundColor: priority.color,
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Text(
+                    priority.name,
+                    style: textTheme.bodySmall,
+                  ),
+                ],
+              ),
           ),
         ),
-        const SizedBox(width: 10),
-        Row(
-          children: [
-            Text(
-              priority.name,
+        const SizedBox(width: 7.5),
+        Card(
+          elevation: 0.5,
+          color: Colors.white70,
+          child: Padding(
+            padding: const EdgeInsets.all(7.0),
+            child: Text(
+              status.name(),
               style: textTheme.bodySmall,
+              textAlign: TextAlign.center,
             ),
-            const SizedBox(width: 10),
-            CircleAvatar(
-              radius: 6,
-              backgroundColor: Colors.black26,
-              child: CircleAvatar(
-                radius: 5,
-                backgroundColor: priority.color,
-              ),
-            ),
-          ],
+          ),
         ),
       ],
     );

--- a/src/lib/widgets/card_widget.dart
+++ b/src/lib/widgets/card_widget.dart
@@ -55,73 +55,77 @@ class CardWidget extends StatelessWidget {
         child: Card(
           child: Padding(
             padding: const EdgeInsets.all(8.0),
-            child: Row(
-              children: <Widget>[
-                /// Left section containing name, status, and description.
-                SizedBox(
-                  width: MediaQuery.of(context).size.width * 0.65,
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Row(
+            child: Column(
+              children: [
+                Row(
+                  children: <Widget>[
+                    /// Left section containing name, status, and description.
+                    SizedBox(
+                      width: MediaQuery.of(context).size.width * 0.65,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          CircleAvatar(
-                            radius: 20,
-                            backgroundImage: AssetImage('assets/images/profile/${uid.hashCode % 6}.jpg'),
+                          Row(
+                            children: [
+                              CircleAvatar(
+                                radius: 20,
+                                backgroundImage: AssetImage('assets/images/profile/${uid.hashCode % 6}.jpg'),
+                              ),
+                              const SizedBox(width: 10),
+                              Expanded(
+                                child: Text(
+                                  name,
+                                  style: textTheme.titleMedium,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ),
+                            ],
                           ),
-                          const SizedBox(width: 10),
-                          Expanded(
+                          const SizedBox(height: 10),
+                          Padding(
+                            padding: const EdgeInsets.all(8.0),
                             child: Text(
-                              name,
-                              style: textTheme.titleMedium,
+                              description,
+                              style: textTheme.bodyMedium,
                               overflow: TextOverflow.ellipsis,
+                              maxLines: 2,
                             ),
                           ),
                         ],
                       ),
-                      const SizedBox(height: 10),
-                      Padding(
-                        padding: const EdgeInsets.all(8.0),
-                        child: Text(
-                          description,
-                          style: textTheme.bodyMedium,
-                          overflow: TextOverflow.ellipsis,
-                          maxLines: 2,
+                    ),
+
+                    /// Right section containing the image.
+                    Expanded(
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.circular(8),
+                        child: Image.network(
+                          imageUrl,
+                          fit: BoxFit.cover,
+                          loadingBuilder: (context, child, loadingProgress) {
+                            if (loadingProgress == null) {
+                              return child;
+                            }
+                            return Center(
+                              child: CircularProgressIndicator(
+                                value: loadingProgress.expectedTotalBytes != null
+                                    ? loadingProgress.cumulativeBytesLoaded /
+                                    loadingProgress.expectedTotalBytes!
+                                    : null,
+                              ),
+                            );
+                          },
+                          errorBuilder: (context, error, stackTrace) =>
+                          const Icon(Icons.error, size: 50, color: Colors.red),
                         ),
                       ),
-                      const SizedBox(height: 15),
-                      _StatusReport(status: status, priority: priority),
-                    ],
-                  ),
-                ),
-
-                /// Right section containing the image.
-                Expanded(
-                  child: ClipRRect(
-                    borderRadius: BorderRadius.circular(8),
-                    child: Image.network(
-                      imageUrl,
-                      fit: BoxFit.cover,
-                      loadingBuilder: (context, child, loadingProgress) {
-                        if (loadingProgress == null) {
-                          return child;
-                        }
-                        return Center(
-                          child: CircularProgressIndicator(
-                            value: loadingProgress.expectedTotalBytes != null
-                                ? loadingProgress.cumulativeBytesLoaded /
-                                    loadingProgress.expectedTotalBytes!
-                                : null,
-                          ),
-                        );
-                      },
-                      errorBuilder: (context, error, stackTrace) =>
-                          const Icon(Icons.error, size: 50, color: Colors.red),
                     ),
-                  ),
+                  ],
                 ),
+                const SizedBox(height: 15),
+                _StatusReport(status: status, priority: priority),
               ],
-            ),
+            )
           ),
         ),
       ),

--- a/src/lib/widgets/card_widget.dart
+++ b/src/lib/widgets/card_widget.dart
@@ -61,7 +61,7 @@ class CardWidget extends StatelessWidget {
                   children: <Widget>[
                     /// Left section containing name, status, and description.
                     SizedBox(
-                      width: MediaQuery.of(context).size.width * 0.65,
+                      width: MediaQuery.of(context).size.width * 0.55,
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
@@ -116,7 +116,7 @@ class CardWidget extends StatelessWidget {
                             );
                           },
                           errorBuilder: (context, error, stackTrace) =>
-                          const Icon(Icons.error, size: 50, color: Colors.red),
+                         const Icon(Icons.image, color: Colors.grey, size: 100,),
                         ),
                       ),
                     ),


### PR DESCRIPTION
This pull request includes significant changes to the citizen report management system, including updates to Firestore rules, the addition of new data access objects (DAOs), controllers, and GUI components for managing and visualizing citizen reports. The most important changes are detailed below:

### Data Access Object (DAO) Implementation:
(`src/lib/gestione_segnalazione_cittadino/gestione_segnalazione_cittadino_dao.dart`)
* Added method to fetch the next set of reports based on the last document retrieved.
* Added control to stop requesting data from the database if no more reports are available.

### Controller Implementation:
(`src/lib/gestione_segnalazione_cittadino/gestione_segnalazione_cittadino_controller.dart`)
* Introduced `CitizenReportManagementController` to handle the interaction between the GUI and DAO for managing citizen reports, including methods for loading citizen data and fetching reports.
* Added asynchronous initialization of the _citizen field to ensure it is properly initialized before use.
Added methods to fetch user reports and handle pagination.

### GUI Implementation:
(`src/lib/gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart`)
* Added `ReportsViewCitizenGUI` class to visualize the list of reports for a citizen's city, including functionalities for loading initial data and handling pagination. 
* Implemented infinite scrolling in the GUI to load more reports as the user scrolls.
* Ensured proper initialization of the userInfo field.
* Added error handling and loading indicators for better user experience.

### Home Page Update:
* Updated `HomePage` to include the new `ReportsViewCitizenGUI` and manage user data loading through `UserManagementController`. (`src/lib/home_page.dart`) [[1]](diffhunk://#diff-b77719795a8b3daa5dc49fa86574212316b557025b5309076802147bbff09e5dR1-R8) [[2]](diffhunk://#diff-b77719795a8b3daa5dc49fa86574212316b557025b5309076802147bbff09e5dR20-L27) [[3]](diffhunk://#diff-b77719795a8b3daa5dc49fa86574212316b557025b5309076802147bbff09e5dR66-R72)

### Home Page Update Important Notes:
`late` variables were changed in `nullable` and nullcheck added beacuse of assertion errors while changing from one page to another. Other branches and devs noted this problem too.

### FireStore Rules Important Update:
(`src/firestore.rules`)
* Updated path to new report position after changes were made to database on per cities subcollections.

### Report Model
(`src/lib/model/report_model.dart')
* Added getCategory method for enum retrieval by name

### report_status_priority
(`src/lib/utils/report_status_priority.dart`)
* Added status and priority static enum getter from their name values


### Pilot Testing:
* Verified that reports load correctly while scrolling.
* Ensured that no additional requests are made once all reports are loaded.
* Tested the initialization of fields to ensure no errors occur.
* Tested assert error on page transitions does not appear after changes.
