### PR TITLE
logout: notify the user for successful logout

### DIFF
--- a/src/lib/main.dart
+++ b/src/lib/main.dart
@@ -38,13 +38,17 @@ Future<void> main() async {
 /// This is the main application widget.
 class FirstPage extends StatelessWidget {
   /// This is the main application widget.
-  const FirstPage({super.key});
+  const FirstPage({super.key, this.isLogout});
+
+  /// This notify the user after logout. (The user will be redirected to
+  /// the login page, so i need a parameter for check the reason of Navigation).
+  final bool? isLogout;
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       theme: ThemeManager().customTheme,
-      home: const _FirstPage(),
+      home: _FirstPage(isLogout: isLogout),
       supportedLocales: const [
         Locale('it'),
       ],
@@ -57,13 +61,32 @@ class FirstPage extends StatelessWidget {
 }
 
 class _FirstPage extends StatefulWidget {
-  const _FirstPage();
+  const _FirstPage({this.isLogout});
+  final bool? isLogout;
 
   @override
   State<_FirstPage> createState() => _FirstPageState();
 }
 
 class _FirstPageState extends State<_FirstPage> {
+  @override
+  void initState() {
+    super.initState();
+    if (widget.isLogout ?? false) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        const message = 'Logout effettuato con successo';
+
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text(message),
+            backgroundColor: Colors.green,
+            duration: Duration(seconds: 7),
+          ),
+        );
+      });
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     // Change color navgationbar

--- a/src/lib/user_management/user_profile_gui.dart
+++ b/src/lib/user_management/user_profile_gui.dart
@@ -106,7 +106,7 @@ class _UserProfileState extends State<UserProfile> {
                             Navigator.pushAndRemoveUntil(
                               context,
                               MaterialPageRoute(
-                                  builder: (context) => const FirstPage()),
+                                  builder: (context) => const FirstPage(isLogout: true)),
                               (route) => false,
                             );
                           } catch (e) {


### PR DESCRIPTION
This pull request includes updates to the `FirstPage` widget to handle user logout notifications. The changes primarily involve adding a new parameter to the `FirstPage` and `_FirstPage` classes and implementing logic to display a logout success message.

Enhancements to logout handling:

* [`src/lib/main.dart`](diffhunk://#diff-a3cd4c6ede3e3d017dc40f4bbb245b1ee93fc268c7368899c71c52da11b26ba4L41-R51): Added an optional `isLogout` parameter to the `FirstPage` and `_FirstPage` constructors to manage logout state. [[1]](diffhunk://#diff-a3cd4c6ede3e3d017dc40f4bbb245b1ee93fc268c7368899c71c52da11b26ba4L41-R51) [[2]](diffhunk://#diff-a3cd4c6ede3e3d017dc40f4bbb245b1ee93fc268c7368899c71c52da11b26ba4L60-R89)
* [`src/lib/main.dart`](diffhunk://#diff-a3cd4c6ede3e3d017dc40f4bbb245b1ee93fc268c7368899c71c52da11b26ba4L60-R89): Updated the `_FirstPageState` class to display a success message using `ScaffoldMessenger` when the user logs out.
* [`src/lib/user_management/user_profile_gui.dart`](diffhunk://#diff-0530a170d0f2c7c33cbf62a9e5e1e9692bb0a8eb8f52a190fbc4fe15628b9763L109-R109): Modified the navigation logic to pass the `isLogout: true` parameter when redirecting to the `FirstPage` after a logout.