### PR TITLE
Test change status

### DIFF
--- a/src/lib/gestione_segnalazione_comune/dettagli_segnalazione_comune_gui.dart
+++ b/src/lib/gestione_segnalazione_comune/dettagli_segnalazione_comune_gui.dart
@@ -21,15 +21,14 @@ class DettagliSegnalazioneComune extends StatefulWidget {
 List<StatusReport> _filteredStatusValues(StatusReport currentStatus) {
   switch (currentStatus) {
     case StatusReport.underReview:
-      return StatusReport.values.sublist(0);
+      return [StatusReport.accepted, StatusReport.inProgress, StatusReport.rejected];
     case StatusReport.accepted:
-      return StatusReport.values.sublist(1);
+      return [StatusReport.inProgress];
     case StatusReport.inProgress:
-      return StatusReport.values.sublist(2);
+      return [StatusReport.completed];
     case StatusReport.completed:
-      return StatusReport.values.sublist(3);
     case StatusReport.rejected:
-      return StatusReport.values.sublist(4);
+      return [];
   }
 }
 
@@ -49,39 +48,39 @@ class _DettagliSegnalazioneState extends State<DettagliSegnalazioneComune> {
     return SingleDetailsReport(
         report: widget._report,
         onStateButton: () => _onChangeValue(
-              title: 'Cambia Stato',
-              objectType: StatusReport.values,
-              objectTarget: widget._report,
-              onValueSelected: (value) {
-                setState(() {
-                  widget._report.status = value;
-                });
-              },
-              clickableValues: _filteredStatusValues(widget._report.status!),
-            ),
+          title: 'Cambia Stato',
+          objectType: StatusReport.values,
+          objectTarget: widget._report,
+          onValueSelected: (value) {
+            setState(() {
+              widget._report.status = value;
+            });
+          },
+          clickableValues: _filteredStatusValues(widget._report.status!),
+        ),
         onPriorityButton: () => onChangeValue(
-              title: 'Cambia Priorità',
-              objectType: PriorityReport.values.where((value) => value != PriorityReport.unset).toList(),
-              objectTarget: widget._report,
-              onValueSelected: (value) {
-                //implement showMessage if it works
-                MunicipalityReportManagementController().editReportPriority(
-                    city: widget._report.city!,
-                    reportId: widget._report.reportId!,
-                    newPriority: value);
-                setState(() {
-                  widget._report.priority = value;
-                });
-              },
-            ));
+          title: 'Cambia Priorità',
+          objectType: PriorityReport.values.where((value) => value != PriorityReport.unset).toList(),
+          objectTarget: widget._report,
+          onValueSelected: (value) {
+            //implement showMessage if it works
+            MunicipalityReportManagementController().editReportPriority(
+                city: widget._report.city!,
+                reportId: widget._report.reportId!,
+                newPriority: value);
+            setState(() {
+              widget._report.priority = value;
+            });
+          },
+        ));
   }
 
   // Need only for priority
   void onChangeValue<T extends Enum>(
       {required String title,
-      required List<T> objectType,
-      required Report objectTarget,
-      required void Function(T) onValueSelected}) {
+        required List<T> objectType,
+        required Report objectTarget,
+        required void Function(T) onValueSelected}) {
     showDialog(
         context: context,
         builder: (context) {
@@ -89,16 +88,16 @@ class _DettagliSegnalazioneState extends State<DettagliSegnalazioneComune> {
               title: Text(title),
               content: SingleChildScrollView(
                   child: ListBody(
-                children: objectType.map((value) {
-                  return ListTile(
-                    title: Text(value.toString()),
-                    onTap: () {
-                      onValueSelected(value);
-                      Navigator.of(context).pop();
-                    },
-                  );
-                }).toList(),
-              )));
+                    children: objectType.map((value) {
+                      return ListTile(
+                        title: Text(value.toString()),
+                        onTap: () {
+                          onValueSelected(value);
+                          Navigator.of(context).pop();
+                        },
+                      );
+                    }).toList(),
+                  )));
         });
   }
 
@@ -129,12 +128,11 @@ class _DettagliSegnalazioneState extends State<DettagliSegnalazioneComune> {
                       selected: selectedValue == value,
                       onTap: clickableValues.contains(value)
                           ? () {
-                              setState(() {
-                                selectedValue = value;
-                              });
-                              onValueSelected(value);
-                              //Navigator.of(context).pop();
-                            }
+                        setState(() {
+                          selectedValue = value;
+                        });
+                        onValueSelected(value);
+                      }
                           : null,
                     );
                   }).toList(),
@@ -148,11 +146,13 @@ class _DettagliSegnalazioneState extends State<DettagliSegnalazioneComune> {
                   child: const Text('Annulla'),
                 ),
                 TextButton(
-                  onPressed: () {
+                  onPressed: clickableValues.isNotEmpty
+                      ? () {
                     // Implement the logic for the confirm action
                     _saveReportState(oldStatusLocal);
                     Navigator.of(context).pop();
-                  },
+                  }
+                      : null,
                   child: const Text('Aggiorna'),
                 ),
               ],

--- a/src/lib/gestione_segnalazione_comune/dettagli_segnalazione_comune_gui.dart
+++ b/src/lib/gestione_segnalazione_comune/dettagli_segnalazione_comune_gui.dart
@@ -21,7 +21,7 @@ class DettagliSegnalazioneComune extends StatefulWidget {
 List<StatusReport> _filteredStatusValues(StatusReport currentStatus) {
   switch (currentStatus) {
     case StatusReport.underReview:
-      return [StatusReport.accepted, StatusReport.inProgress, StatusReport.rejected];
+      return [StatusReport.accepted, StatusReport.rejected];
     case StatusReport.accepted:
       return [StatusReport.inProgress];
     case StatusReport.inProgress:

--- a/src/lib/gestione_segnalazione_comune/dettagli_segnalazione_comune_gui.dart
+++ b/src/lib/gestione_segnalazione_comune/dettagli_segnalazione_comune_gui.dart
@@ -48,16 +48,16 @@ class _DettagliSegnalazioneState extends State<DettagliSegnalazioneComune> {
     return SingleDetailsReport(
         report: widget._report,
         onStateButton: () => _onChangeValue(
-          title: 'Cambia Stato',
-          objectType: StatusReport.values,
-          objectTarget: widget._report,
-          onValueSelected: (value) {
-            setState(() {
-              widget._report.status = value;
-            });
-          },
-          clickableValues: _filteredStatusValues(widget._report.status!),
-        ),
+              title: 'Cambia Stato',
+              objectType: StatusReport.values,
+              objectTarget: widget._report,
+              onValueSelected: (value) {
+                setState(() {
+                  widget._report.status = value;
+                });
+              },
+              clickableValues: _filteredStatusValues(widget._report.status!),
+            ),
         onPriorityButton: () => onChangeValue(
               title: 'Cambia Priorità',
               objectType: PriorityReport.values
@@ -80,9 +80,9 @@ class _DettagliSegnalazioneState extends State<DettagliSegnalazioneComune> {
   // Need only for priority
   void onChangeValue<T extends Enum>(
       {required String title,
-        required List<T> objectType,
-        required Report objectTarget,
-        required void Function(T) onValueSelected}) {
+      required List<T> objectType,
+      required Report objectTarget,
+      required void Function(T) onValueSelected}) {
     showDialog(
         context: context,
         builder: (context) {
@@ -90,16 +90,16 @@ class _DettagliSegnalazioneState extends State<DettagliSegnalazioneComune> {
               title: Text(title),
               content: SingleChildScrollView(
                   child: ListBody(
-                    children: objectType.map((value) {
-                      return ListTile(
-                        title: Text(value.toString()),
-                        onTap: () {
-                          onValueSelected(value);
-                          Navigator.of(context).pop();
-                        },
-                      );
-                    }).toList(),
-                  )));
+                children: objectType.map((value) {
+                  return ListTile(
+                    title: Text(value.toString()),
+                    onTap: () {
+                      onValueSelected(value);
+                      Navigator.of(context).pop();
+                    },
+                  );
+                }).toList(),
+              )));
         });
   }
 
@@ -130,11 +130,11 @@ class _DettagliSegnalazioneState extends State<DettagliSegnalazioneComune> {
                       selected: selectedValue == value,
                       onTap: clickableValues.contains(value)
                           ? () {
-                        setState(() {
-                          selectedValue = value;
-                        });
-                        onValueSelected(value);
-                      }
+                              setState(() {
+                                selectedValue = value;
+                              });
+                              onValueSelected(value);
+                            }
                           : null,
                     );
                   }).toList(),
@@ -150,10 +150,10 @@ class _DettagliSegnalazioneState extends State<DettagliSegnalazioneComune> {
                 TextButton(
                   onPressed: clickableValues.isNotEmpty
                       ? () {
-                    // Implement the logic for the confirm action
-                    _saveReportState(oldStatusLocal);
-                    Navigator.of(context).pop();
-                  }
+                          // Implement the logic for the confirm action
+                          _saveReportState(oldStatusLocal);
+                          Navigator.of(context).pop();
+                        }
                       : null,
                   child: const Text('Aggiorna'),
                 ),

--- a/src/lib/gestione_segnalazione_comune/dettagli_segnalazione_comune_gui.dart
+++ b/src/lib/gestione_segnalazione_comune/dettagli_segnalazione_comune_gui.dart
@@ -34,12 +34,13 @@ List<StatusReport> _filteredStatusValues(StatusReport currentStatus) {
 }
 
 class _DettagliSegnalazioneState extends State<DettagliSegnalazioneComune> {
-  void _saveReportState() {
+  void _saveReportState(StatusReport oldStatus) {
     // Implement the logic to save the current state of the report
     MunicipalityReportManagementController(context: context).editReportStatus(
       city: widget._report.city!,
       reportId: widget._report.reportId!,
       newStatus: widget._report.status!,
+      currentStatus: oldStatus,
     );
   }
 
@@ -112,6 +113,8 @@ class _DettagliSegnalazioneState extends State<DettagliSegnalazioneComune> {
     showDialog(
       context: context,
       builder: (context) {
+        // Save the current state of the report
+        final oldStatusLocal = objectTarget.status as StatusReport;
         T? selectedValue = objectTarget.status as T;
         return StatefulBuilder(
           builder: (context, setState) {
@@ -147,7 +150,7 @@ class _DettagliSegnalazioneState extends State<DettagliSegnalazioneComune> {
                 TextButton(
                   onPressed: () {
                     // Implement the logic for the confirm action
-                    _saveReportState();
+                    _saveReportState(oldStatusLocal);
                     Navigator.of(context).pop();
                   },
                   child: const Text('Aggiorna'),

--- a/src/lib/gestione_segnalazione_comune/gestione_segnalazione_comune_controller.dart
+++ b/src/lib/gestione_segnalazione_comune/gestione_segnalazione_comune_controller.dart
@@ -54,8 +54,8 @@ class MunicipalityReportManagementController {
   ///
   /// ### Parameters:
   /// - `redirectPage`: The page to redirect to after loading the municipality data.
-  MunicipalityReportManagementController({rdao, udao, this.redirectPage, context})
-      : _context = context, _reportDAO = rdao ?? MunicipalityReportManagementDAO(), _userManagementDAO = udao ?? UserManagementDAO() {
+  MunicipalityReportManagementController({reportDAO, userDAO, this.redirectPage, context})
+      : _context = context, _reportDAO = reportDAO ?? MunicipalityReportManagementDAO(), _userManagementDAO = userDAO ?? UserManagementDAO() {
     _loadMunicipality();
   }
 
@@ -70,12 +70,12 @@ class MunicipalityReportManagementController {
   /// - `redirectPage`: The page to redirect to after loading the municipality data.
   /// - `context`: The build context for showing messages.
   MunicipalityReportManagementController.forTest({
-    rdao,
-    udao,
-    m,
+    reportDAO,
+    userDAO,
+    municipality,
     this.redirectPage, context,
-  })  : _reportDAO = rdao,
-        _context = context, _userManagementDAO = udao, _municipality = m ;
+  })  : _reportDAO = reportDAO,
+        _context = context, _userManagementDAO = userDAO, _municipality = municipality ;
 
   /// Edits the status of a specific report.
   ///

--- a/src/lib/gestione_segnalazione_comune/gestione_segnalazione_comune_controller.dart
+++ b/src/lib/gestione_segnalazione_comune/gestione_segnalazione_comune_controller.dart
@@ -135,12 +135,32 @@ class MunicipalityReportManagementController {
 
   /// Checks if the status change is valid.
   /// This method checks if the status change is valid based on the current and new status.
-  /// If the status change is not valid, it throws an exception.
+  /// If the status change is not valid, it throws an exception with the corresponding error message.
+  /// The following rules are enforced:
+  /// 1. Transitions from 'completed' or 'rejected' are not allowed.
+  /// 2. 'rejected' can only be accessed from 'underReview'.
+  /// 3. Ensure the new status follows the correct order.
+  /// 4. Check if newStatus is within the valid range.
   /// Parameters:
   /// - [currentStatus]: The current status of the report.
   /// - [newStatus]: The new status to set for the report.
   /// Throws:
-  /// - An exception if the status change is not valid.
+  /// - An exception with the corresponding error message if the status change is not valid.
+  /// Example:
+  /// ```dart
+  /// isValidStatusChange(
+  ///  currentStatus: StatusReport.underReview,
+  ///  newStatus: StatusReport.accepted,
+  ///  );
+  ///  ```
+  ///  This example checks if the status change from 'underReview' to 'accepted' is valid.
+  ///  If the status change is not valid, it throws an exception with the corresponding error message.
+  ///  ```dart
+  ///  isValidStatusChange(
+  ///  currentStatus: StatusReport.inProgress,
+  ///  newStatus: StatusReport.completed,
+  ///  );
+  ///  ```
   void isValidStatusChange(StatusReport currentStatus, StatusReport newStatus) {
     // Get the indices of the current and new status
     final currentStatusIndex = currentStatus.index;
@@ -155,7 +175,7 @@ class MunicipalityReportManagementController {
     // Rule 2: 'rejected' can only be accessed from 'underReview'
     if (newStatus == StatusReport.rejected &&
         currentStatus != StatusReport.underReview) {
-      throw ('La transizione a "rejected" è consentita solo dallo stato "underReview".');
+      throw ('La transizione a "Rifiutata" è consentita solo dallo stato "In Verifica".');
     }
 
     // Rule 3: Ensure the new status follows the correct order

--- a/src/lib/gestione_segnalazione_comune/gestione_segnalazione_comune_controller.dart
+++ b/src/lib/gestione_segnalazione_comune/gestione_segnalazione_comune_controller.dart
@@ -135,19 +135,28 @@ class MunicipalityReportManagementController {
   /// Throws:
   /// - An exception if the status change is not valid.
   void isValidStatusChange(StatusReport currentStatus, StatusReport newStatus) {
-    final currentStatusIndex = StatusReport.values.indexOf(currentStatus);
-    final newStatusIndex = StatusReport.values.indexOf(newStatus);
+    // Get the indices of the current and new status
+    final currentStatusIndex = currentStatus.index;
+    final newStatusIndex = newStatus.index;
 
-    if (currentStatusIndex == StatusReport.rejected.index) {
-      throw ('Transizione da stato Scartata non consentita.');
+    // Rule 1: Transitions from 'completed' or 'rejected' are not allowed
+    if (currentStatus == StatusReport.completed || currentStatus == StatusReport.rejected) {
+      throw ('Transizione da stato ${currentStatus.name} non consentita.');
     }
 
+    // Rule 2: 'rejected' can only be accessed from 'underReview'
+    if (newStatus == StatusReport.rejected && currentStatus != StatusReport.underReview) {
+      throw ('La transizione a "rejected" è consentita solo dallo stato "underReview".');
+    }
+
+    // Rule 3: Ensure the new status follows the correct order
+    if (newStatusIndex != currentStatusIndex + 1 && newStatus != StatusReport.rejected) {
+      throw ('Transizione non valida. Lo stato successivo consentito è ${StatusReport.values[currentStatusIndex + 1].name}.');
+    }
+
+    // Rule 4: Check if newStatus is within the valid range
     if (newStatusIndex < StatusReport.underReview.index || newStatusIndex > StatusReport.rejected.index) {
-      throw ('Stato non valido');
-    }
-
-    if (newStatusIndex < currentStatusIndex) {
-      throw ('Transizione verso stato precedente non consentita.');
+      throw ('Stato non valido: ${newStatus.name}');
     }
   }
 

--- a/src/lib/gestione_segnalazione_comune/gestione_segnalazione_comune_controller.dart
+++ b/src/lib/gestione_segnalazione_comune/gestione_segnalazione_comune_controller.dart
@@ -40,26 +40,42 @@ import 'gestione_segnalazione_comune_dao.dart';
 class MunicipalityReportManagementController {
   /// The page to navigate to after certain actions, such as adding a report.
   final Widget? redirectPage;
-
   /// An instance of `MunicipalityReportManagementDAO` to handle data operations.
-  final MunicipalityReportManagementDAO _reportDAO =
-      MunicipalityReportManagementDAO();
-  final UserManagementDAO _userManagementDAO = UserManagementDAO();
+  final MunicipalityReportManagementDAO _reportDAO;
+  final UserManagementDAO _userManagementDAO ;
   final BuildContext? _context;
   Municipality? _municipality;
-  final Completer<Municipality> _municipalityCompleter =
-      Completer<Municipality>();
+  final Completer<Municipality> _municipalityCompleter = Completer<Municipality>();
 
-  /// Constructs a `CitizenReportManagementController`.
+
+  /// Constructs a `MunicipalityReportManagementController`.
   ///
   /// This constructor initializes the controller and loads the municipality data.
   ///
   /// ### Parameters:
   /// - `redirectPage`: The page to redirect to after loading the municipality data.
-  MunicipalityReportManagementController({this.redirectPage, context})
-      : _context = context {
+  MunicipalityReportManagementController({rdao, udao, this.redirectPage, context})
+      : _context = context, _reportDAO = rdao ?? MunicipalityReportManagementDAO(), _userManagementDAO = udao ?? UserManagementDAO() {
     _loadMunicipality();
   }
+
+  /// Constructs a `MunicipalityReportManagementController` for testing purposes.
+  ///
+  /// This constructor initializes the controller with mock data for testing.
+  ///
+  /// ### Parameters:
+  /// - `rdao`: The mock DAO for report management.
+  /// - `udao`: The mock DAO for user management.
+  /// - `m`: The mock municipality data.
+  /// - `redirectPage`: The page to redirect to after loading the municipality data.
+  /// - `context`: The build context for showing messages.
+  MunicipalityReportManagementController.forTest({
+    rdao,
+    udao,
+    m,
+    this.redirectPage, context,
+  })  : _reportDAO = rdao,
+        _context = context, _userManagementDAO = udao, _municipality = m ;
 
   /// Edits the status of a specific report.
   ///
@@ -123,15 +139,15 @@ class MunicipalityReportManagementController {
     final newStatusIndex = StatusReport.values.indexOf(newStatus);
 
     if (currentStatusIndex == StatusReport.rejected.index) {
-      throw Exception('Transizione da stato Scartata non consentita.');
+      throw ('Transizione da stato Scartata non consentita.');
     }
 
     if (newStatusIndex < StatusReport.underReview.index || newStatusIndex > StatusReport.rejected.index) {
-      throw Exception('Stato non valido');
+      throw ('Stato non valido');
     }
 
     if (newStatusIndex < currentStatusIndex) {
-      throw Exception('Transizione verso stato precedente non consentita.');
+      throw ('Transizione verso stato precedente non consentita.');
     }
   }
 

--- a/src/lib/gestione_segnalazione_comune/gestione_segnalazione_comune_controller.dart
+++ b/src/lib/gestione_segnalazione_comune/gestione_segnalazione_comune_controller.dart
@@ -96,7 +96,7 @@ class MunicipalityReportManagementController {
       if (_context != null) {
         showMessage(
           _context,
-          message: 'Stato aggiornato correttamente',
+          message: 'Stato aggiornato correttamente.',
         );
       }
     } catch (e) {
@@ -123,7 +123,7 @@ class MunicipalityReportManagementController {
     final newStatusIndex = StatusReport.values.indexOf(newStatus);
 
     if (currentStatusIndex == StatusReport.rejected.index) {
-      throw Exception('Transizione da stato scartata non consentita.');
+      throw Exception('Transizione da stato Scartata non consentita.');
     }
 
     if (newStatusIndex < StatusReport.underReview.index || newStatusIndex > StatusReport.rejected.index) {

--- a/src/lib/gestione_segnalazione_comune/gestione_segnalazione_comune_controller.dart
+++ b/src/lib/gestione_segnalazione_comune/gestione_segnalazione_comune_controller.dart
@@ -54,7 +54,7 @@ class MunicipalityReportManagementController {
   ///
   /// ### Parameters:
   /// - `redirectPage`: The page to redirect to after loading the municipality data.
-  MunicipalityReportManagementController({reportDAO, userDAO, this.redirectPage, context})
+  MunicipalityReportManagementController({reportDAO, userManagementDAO, this.redirectPage, context})
       : _context = context, _reportDAO = reportDAO ?? MunicipalityReportManagementDAO(), _userManagementDAO = userManagementDAO ?? UserManagementDAO() {
     _loadMunicipality();
   }

--- a/src/lib/gestione_segnalazione_comune/gestione_segnalazione_comune_controller.dart
+++ b/src/lib/gestione_segnalazione_comune/gestione_segnalazione_comune_controller.dart
@@ -87,8 +87,10 @@ class MunicipalityReportManagementController {
     required String city,
     required String reportId,
     required StatusReport newStatus,
+    required StatusReport currentStatus,
   }) async {
     try {
+      isValidStatusChange(currentStatus, newStatus);
       await _reportDAO.editReportStatus(
           city: city, reportId: reportId, newStatus: newStatus);
       if (_context != null) {
@@ -101,10 +103,35 @@ class MunicipalityReportManagementController {
       if (_context != null) {
         showMessage(
           _context,
-          message: 'Errore durante l\'aggiornamento dello stato',
+          message: e,
           isError: true,
         );
       }
+    }
+  }
+
+  /// Checks if the status change is valid.
+  /// This method checks if the status change is valid based on the current and new status.
+  /// If the status change is not valid, it throws an exception.
+  /// Parameters:
+  /// - [currentStatus]: The current status of the report.
+  /// - [newStatus]: The new status to set for the report.
+  /// Throws:
+  /// - An exception if the status change is not valid.
+  void isValidStatusChange(StatusReport currentStatus, StatusReport newStatus) {
+    final currentStatusIndex = StatusReport.values.indexOf(currentStatus);
+    final newStatusIndex = StatusReport.values.indexOf(newStatus);
+
+    if (currentStatusIndex == StatusReport.rejected.index) {
+      throw Exception('Transizione da stato scartata non consentita.');
+    }
+
+    if (newStatusIndex < StatusReport.underReview.index || newStatusIndex > StatusReport.rejected.index) {
+      throw Exception('Stato non valido');
+    }
+
+    if (newStatusIndex < currentStatusIndex) {
+      throw Exception('Transizione verso stato precedente non consentita.');
     }
   }
 

--- a/src/lib/gestione_segnalazione_comune/gestione_segnalazione_comune_controller.dart
+++ b/src/lib/gestione_segnalazione_comune/gestione_segnalazione_comune_controller.dart
@@ -40,13 +40,14 @@ import 'gestione_segnalazione_comune_dao.dart';
 class MunicipalityReportManagementController {
   /// The page to navigate to after certain actions, such as adding a report.
   final Widget? redirectPage;
+
   /// An instance of `MunicipalityReportManagementDAO` to handle data operations.
   final MunicipalityReportManagementDAO _reportDAO;
-  final UserManagementDAO _userManagementDAO ;
+  final UserManagementDAO _userManagementDAO;
   final BuildContext? _context;
   Municipality? _municipality;
-  final Completer<Municipality> _municipalityCompleter = Completer<Municipality>();
-
+  final Completer<Municipality> _municipalityCompleter =
+      Completer<Municipality>();
 
   /// Constructs a `MunicipalityReportManagementController`.
   ///
@@ -54,8 +55,11 @@ class MunicipalityReportManagementController {
   ///
   /// ### Parameters:
   /// - `redirectPage`: The page to redirect to after loading the municipality data.
-  MunicipalityReportManagementController({reportDAO, userManagementDAO, this.redirectPage, context})
-      : _context = context, _reportDAO = reportDAO ?? MunicipalityReportManagementDAO(), _userManagementDAO = userManagementDAO ?? UserManagementDAO() {
+  MunicipalityReportManagementController(
+      {reportDAO, userManagementDAO, this.redirectPage, context})
+      : _context = context,
+        _reportDAO = reportDAO ?? MunicipalityReportManagementDAO(),
+        _userManagementDAO = userManagementDAO ?? UserManagementDAO() {
     _loadMunicipality();
   }
 
@@ -73,9 +77,12 @@ class MunicipalityReportManagementController {
     reportDAO,
     userManagementDAO,
     municipality,
-    this.redirectPage, context,
+    this.redirectPage,
+    context,
   })  : _reportDAO = reportDAO,
-        _context = context, _userManagementDAO = userManagementDAO, _municipality = municipality ;
+        _context = context,
+        _userManagementDAO = userManagementDAO,
+        _municipality = municipality;
 
   /// Edits the status of a specific report.
   ///
@@ -140,22 +147,26 @@ class MunicipalityReportManagementController {
     final newStatusIndex = newStatus.index;
 
     // Rule 1: Transitions from 'completed' or 'rejected' are not allowed
-    if (currentStatus == StatusReport.completed || currentStatus == StatusReport.rejected) {
+    if (currentStatus == StatusReport.completed ||
+        currentStatus == StatusReport.rejected) {
       throw ('Transizione da stato ${currentStatus.name} non consentita.');
     }
 
     // Rule 2: 'rejected' can only be accessed from 'underReview'
-    if (newStatus == StatusReport.rejected && currentStatus != StatusReport.underReview) {
+    if (newStatus == StatusReport.rejected &&
+        currentStatus != StatusReport.underReview) {
       throw ('La transizione a "rejected" è consentita solo dallo stato "underReview".');
     }
 
     // Rule 3: Ensure the new status follows the correct order
-    if (newStatusIndex != currentStatusIndex + 1 && newStatus != StatusReport.rejected) {
+    if (newStatusIndex != currentStatusIndex + 1 &&
+        newStatus != StatusReport.rejected) {
       throw ('Transizione non valida. Lo stato successivo consentito è ${StatusReport.values[currentStatusIndex + 1].name}.');
     }
 
     // Rule 4: Check if newStatus is within the valid range
-    if (newStatusIndex < StatusReport.underReview.index || newStatusIndex > StatusReport.rejected.index) {
+    if (newStatusIndex < StatusReport.underReview.index ||
+        newStatusIndex > StatusReport.rejected.index) {
       throw ('Stato non valido: ${newStatus.name}');
     }
   }
@@ -188,16 +199,18 @@ class MunicipalityReportManagementController {
     required PriorityReport newPriority,
   }) async {
     try {
-      if (newPriority == PriorityReport.high || newPriority == PriorityReport.low || newPriority == PriorityReport.medium) {
-        await _reportDAO.editReportPriority(city: city, reportId: reportId, newPriority: newPriority);
+      if (newPriority == PriorityReport.high ||
+          newPriority == PriorityReport.low ||
+          newPriority == PriorityReport.medium) {
+        await _reportDAO.editReportPriority(
+            city: city, reportId: reportId, newPriority: newPriority);
         if (_context != null) {
           showMessage(
             _context,
             message: 'Priorità segnalazione cambiata',
           );
         }
-      }
-      else{
+      } else {
         if (_context != null) {
           showMessage(
             _context,

--- a/src/lib/user_management/user_management_controller.dart
+++ b/src/lib/user_management/user_management_controller.dart
@@ -53,8 +53,8 @@ class UserManagementController {
   /// Returns:
   /// - A `Future<bool>` indicating whether the authentication was successful.
   Future<bool> _validateAuth(BuildContext context, email, password) async {
-    final bool result = await userManagementDAO
-        .signInWithEmailAndPassword(email: email, password: password);
+    final bool result = await userManagementDAO.signInWithEmailAndPassword(
+        email: email, password: password);
 
     if (result) {
       Navigator.pushAndRemoveUntil(
@@ -103,8 +103,8 @@ class UserManagementController {
   /// - [currentPassword]: The user's current password for authentication.
   Future<void> changeEmail(BuildContext context,
       {required String newEmail, required String currentPassword}) async {
-    await userManagementDAO
-        .updateEmail(newEmail: newEmail, currentPassword: currentPassword);
+    await userManagementDAO.updateEmail(
+        newEmail: newEmail, currentPassword: currentPassword);
   }
 
   /// Changes the user's password.
@@ -248,10 +248,9 @@ class UserManagementController {
   ///   print("User type could not be determined");
   /// }
   /// ```
-Future<GenericUser?> determineUserType() async {
-  return await userManagementDAO.determineUserType();
-}
-
+  Future<GenericUser?> determineUserType() async {
+    return await userManagementDAO.determineUserType();
+  }
 
   /// Returns the current user.
   User? getcurrentUser() {

--- a/src/lib/user_management/user_profile_gui.dart
+++ b/src/lib/user_management/user_profile_gui.dart
@@ -12,15 +12,21 @@ import '../utils/snackbar_riscontro.dart';
 class UserProfile extends StatefulWidget {
   /// The controller for user management operations if not provided a new one is created.
   final UserManagementController userController;
+
   /// The page to navigate to after a successful logout.
   final Widget redirectLogOutPage;
+
   /// Widget stateful for viewing and editing user profile data.
   /// Params:
   /// - [controller]: The controller for user management operations if not provided a new one is created from UserManagementController.
   /// - [key]: The key for the widget.
   /// - [redirectLogOutPage]: The page to navigate to after a successful logout if not provided a new one is created from FirstPage.
-    UserProfile({UserManagementController? controller, super.key, Widget? redirectLogOutPage})
-    : userController = controller ?? UserManagementController(), redirectLogOutPage = redirectLogOutPage ??  const FirstPage();
+  UserProfile(
+      {UserManagementController? controller,
+      super.key,
+      Widget? redirectLogOutPage})
+      : userController = controller ?? UserManagementController(),
+        redirectLogOutPage = redirectLogOutPage ?? const FirstPage();
 
   @override
   State<UserProfile> createState() => _UserProfileState(userController);
@@ -115,7 +121,8 @@ class _UserProfileState extends State<UserProfile> {
                             Navigator.pushAndRemoveUntil(
                               context,
                               MaterialPageRoute(
-                                  builder: (context) => widget.redirectLogOutPage),
+                                  builder: (context) =>
+                                      widget.redirectLogOutPage),
                               (route) => false,
                             );
                           } catch (e) {
@@ -188,7 +195,6 @@ class _UserProfileState extends State<UserProfile> {
       'Città': userData['city'] ?? 'N/A',
       'CAP': userData['cap'] ?? 'N/A',
     };
-
 
     return personalFields.keys.toList().map((field) {
       if (field == 'Indirizzo') {

--- a/src/test/select_priority_test.dart
+++ b/src/test/select_priority_test.dart
@@ -61,8 +61,8 @@ void main() {
         home: Scaffold(
           body: Builder(builder: (context) {
             final controller = MunicipalityReportManagementController.forTest(
-              reportDao: mockReportDAO,
-              userManagementDao: mockUserDAO,
+              reportDAO: mockReportDAO,
+              userManagementDAO: mockUserDAO,
               context: context,
               municipality: m,
             );
@@ -97,8 +97,8 @@ void main() {
         home: Scaffold(
           body: Builder(builder: (context) {
             final controller = MunicipalityReportManagementController.forTest(
-              reportDao: mockReportDAO,
-              userManagementDao: mockUserDAO,
+              reportDAO: mockReportDAO,
+              userManagementDAO: mockUserDAO,
               context: context,
               municipality: m,
             );

--- a/src/test/status_change_test.dart
+++ b/src/test/status_change_test.dart
@@ -123,7 +123,7 @@ void _testState(
         body: Builder(builder: (context) {
           final controller = MunicipalityReportManagementController.forTest(
             reportDAO: mockReportDAO,
-            userDAO: mockUserDAO,
+            userManagementDAO: mockUserDAO,
             context: context,
             municipality: municipality,
           );

--- a/src/test/status_change_test.dart
+++ b/src/test/status_change_test.dart
@@ -12,7 +12,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 
-
 /// Test Case for Modifica Stato Segnalazione
 ///
 ///
@@ -25,30 +24,38 @@ import 'package:mockito/mockito.dart';
 
 // Mock del ReportDAO
 class MockReportDAO extends Mock implements MunicipalityReportManagementDAO {}
+
 class MockUserDAO extends Mock implements UserManagementDAO {}
+
 class MockBuildContext extends Mock implements BuildContext {}
+
 class MockUser extends Mock implements User {}
 
-Municipality m= Municipality(user: MockUser(), municipalityName: 'municipalityName');
+Municipality m =
+    Municipality(user: MockUser(), municipalityName: 'municipalityName');
 
-Report r= Report(
+Report r = Report(
     city: 'testCity',
     reportId: 'report123',
     priority: PriorityReport.high,
     status: StatusReport.completed,
     title: 'title',
     description: 'description',
-    reportDate:  Timestamp.now(),
+    reportDate: Timestamp.now(),
     address: {'street': 'N/A', 'number': 'N/A'},
     location: const GeoPoint(0, 0),
-    photo: '', uid: 'uid', authorFirstName: 'authorFirstName', authorLastName: 'authorLastName'
-);
+    photo: '',
+    uid: 'uid',
+    authorFirstName: 'authorFirstName',
+    authorLastName: 'authorLastName');
 
 class FakeReportDAO extends Fake implements MunicipalityReportManagementDAO {
   @override
-  Future<void> editReportStatus({required String? city,
+  Future<void> editReportStatus({
+    required String? city,
     required String? reportId,
-    required StatusReport newStatus,}) async {
+    required StatusReport newStatus,
+  }) async {
     r.status = newStatus;
   }
 }
@@ -58,19 +65,37 @@ void main() {
   // enum not valid is tested by enum itself
 
   /// TC_7.0.2 StatusReport Scartata Expected: changeStatus Fails
-  _testState(description: 'TC_7.0.2 StatusReport Scartata Expected: changeStatus Fails', currentStatus: StatusReport.rejected, newStatus: StatusReport.inProgress, expectedStatus: StatusReport.rejected);
+  _testState(
+      description:
+          'TC_7.0.2 StatusReport Scartata Expected: changeStatus Fails',
+      currentStatus: StatusReport.rejected,
+      newStatus: StatusReport.inProgress,
+      expectedStatus: StatusReport.rejected);
 
   /// TC_7.0.3 StatusReport current After new Expected: changeStatus Fails
-  _testState(description: 'TC_7.0.3 StatusReport current After new Expected: changeStatus Fails', currentStatus: StatusReport.completed, newStatus: StatusReport.inProgress, expectedStatus: StatusReport.completed);
+  _testState(
+      description:
+          'TC_7.0.3 StatusReport current After new Expected: changeStatus Fails',
+      currentStatus: StatusReport.completed,
+      newStatus: StatusReport.inProgress,
+      expectedStatus: StatusReport.completed);
 
   /// TC_7.0.4 StatusReport current Before new and valid Expected: changeStatus is Accepted
-  _testState(description: 'TC_7.0.3 StatusReport current After new Expected: changeStatus Fails', currentStatus: StatusReport.inProgress, newStatus: StatusReport.completed, expectedStatus: StatusReport.completed);
+  _testState(
+      description:
+          'TC_7.0.3 StatusReport current After new Expected: changeStatus Fails',
+      currentStatus: StatusReport.inProgress,
+      newStatus: StatusReport.completed,
+      expectedStatus: StatusReport.completed);
 }
 
-void _testState({required description, required StatusReport currentStatus, required StatusReport newStatus, required StatusReport expectedStatus}) {
-
-  final mockReportDAO = FakeReportDAO();  // Istanza del mock del DAO
-  final mockUserDAO=MockUserDAO();
+void _testState(
+    {required description,
+    required StatusReport currentStatus,
+    required StatusReport newStatus,
+    required StatusReport expectedStatus}) {
+  final mockReportDAO = FakeReportDAO(); // Istanza del mock del DAO
+  final mockUserDAO = MockUserDAO();
   const city = 'testCity';
   const reportId = 'report123';
 

--- a/src/test/status_change_test.dart
+++ b/src/test/status_change_test.dart
@@ -1,7 +1,16 @@
 // This is the test for the status change of the report made by the municipality.
 
+import 'package:civiconnect/gestione_segnalazione_comune/gestione_segnalazione_comune_controller.dart';
+import 'package:civiconnect/gestione_segnalazione_comune/gestione_segnalazione_comune_dao.dart';
+import 'package:civiconnect/model/report_model.dart';
+import 'package:civiconnect/model/users_model.dart';
+import 'package:civiconnect/user_management/user_management_dao.dart';
 import 'package:civiconnect/utils/report_status_priority.dart';
-import 'package:mockito/annotations.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
 
 
 /// Test Case for Modifica Stato Segnalazione
@@ -11,4 +20,91 @@ import 'package:mockito/annotations.dart';
 /// TC_7.0.2 StatusReport Scartata Expected: changeStatus Fails
 /// TC_7.0.3 StatusReport current After new Expected: changeStatus Fails
 /// TC_7.0.4 StatusReport current Before new and valid Expected: changeStatus is Accepted
+/// dart run build_runner build
+///
 
+// Mock del ReportDAO
+class MockReportDAO extends Mock implements MunicipalityReportManagementDAO {}
+class MockUserDAO extends Mock implements UserManagementDAO {}
+class MockBuildContext extends Mock implements BuildContext {}
+class MockUser extends Mock implements User {}
+
+Municipality m= Municipality(user: MockUser(), municipalityName: 'municipalityName');
+
+Report r= Report(
+    city: 'testCity',
+    reportId: 'report123',
+    priority: PriorityReport.high,
+    status: StatusReport.completed,
+    title: 'title',
+    description: 'description',
+    reportDate:  Timestamp.now(),
+    address: {'street': 'N/A', 'number': 'N/A'},
+    location: const GeoPoint(0, 0),
+    photo: '', uid: 'uid', authorFirstName: 'authorFirstName', authorLastName: 'authorLastName'
+);
+
+class FakeReportDAO extends Fake implements MunicipalityReportManagementDAO {
+  @override
+  Future<void> editReportStatus({required String? city,
+    required String? reportId,
+    required StatusReport newStatus,}) async {
+    r.status = newStatus;
+  }
+}
+
+void main() {
+  /// TC_7.0.1 invalid StatusReport Expected: changeStatus Fails
+  // enum not valid is tested by enum itself
+
+  /// TC_7.0.2 StatusReport Scartata Expected: changeStatus Fails
+  _testState(description: 'TC_7.0.2 StatusReport Scartata Expected: changeStatus Fails', currentStatus: StatusReport.rejected, newStatus: StatusReport.inProgress, expectedStatus: StatusReport.rejected);
+
+  /// TC_7.0.3 StatusReport current After new Expected: changeStatus Fails
+  _testState(description: 'TC_7.0.3 StatusReport current After new Expected: changeStatus Fails', currentStatus: StatusReport.completed, newStatus: StatusReport.inProgress, expectedStatus: StatusReport.completed);
+
+  /// TC_7.0.4 StatusReport current Before new and valid Expected: changeStatus is Accepted
+  _testState(description: 'TC_7.0.3 StatusReport current After new Expected: changeStatus Fails', currentStatus: StatusReport.inProgress, newStatus: StatusReport.completed, expectedStatus: StatusReport.completed);
+}
+
+void _testState({required description, required StatusReport currentStatus, required StatusReport newStatus, required StatusReport expectedStatus}) {
+
+  final mockReportDAO = FakeReportDAO();  // Istanza del mock del DAO
+  final mockUserDAO=MockUserDAO();
+  const city = 'testCity';
+  const reportId = 'report123';
+
+  testWidgets(description, (tester) async {
+    r.status = currentStatus;
+    // Costruisci un widget con un contesto reale
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Builder(builder: (context) {
+          final controller = MunicipalityReportManagementController.forTest(
+            rdao: mockReportDAO,
+            udao: mockUserDAO,
+            context: context,
+            m: m,
+          );
+
+          return ElevatedButton(
+            onPressed: () async {
+              await controller.editReportStatus(
+                city: city,
+                reportId: reportId,
+                newStatus: newStatus,
+                currentStatus: currentStatus,
+              );
+            },
+            child: const Text('Test Button'),
+          );
+        }),
+      ),
+    ));
+
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pumpAndSettle();
+
+    expect(r.status, equals(expectedStatus));
+  });
+}

--- a/src/test/status_change_test.dart
+++ b/src/test/status_change_test.dart
@@ -96,7 +96,6 @@ void main() {
       newStatus: StatusReport.completed,
       expectedStatus: StatusReport.accepted);
 
-
   /// TC_7.0.6 The current status in the StatusReport precedes the new status, adhering to the correct order Expected: changeStatus is Accepted
   _testState(
       description:

--- a/src/test/status_change_test.dart
+++ b/src/test/status_change_test.dart
@@ -1,0 +1,14 @@
+// This is the test for the status change of the report made by the municipality.
+
+import 'package:civiconnect/utils/report_status_priority.dart';
+import 'package:mockito/annotations.dart';
+
+
+/// Test Case for Modifica Stato Segnalazione
+///
+///
+/// TC_7.0.1 invalid StatusReport Expected: changeStatus Fails
+/// TC_7.0.2 StatusReport Scartata Expected: changeStatus Fails
+/// TC_7.0.3 StatusReport current After new Expected: changeStatus Fails
+/// TC_7.0.4 StatusReport current Before new and valid Expected: changeStatus is Accepted
+

--- a/src/test/status_change_test.dart
+++ b/src/test/status_change_test.dart
@@ -78,7 +78,7 @@ void main() {
           'TC_7.0.3 StatusReport from not in Attesa to Scartata Expected: changeStatus Fails',
       currentStatus: StatusReport.inProgress,
       newStatus: StatusReport.rejected,
-      expectedStatus: StatusReport.rejected);
+      expectedStatus: StatusReport.inProgress);
 
   /// TC_7.0.4 transition to previus state Expected: changeStatus Fails
   _testState(

--- a/src/test/status_change_test.dart
+++ b/src/test/status_change_test.dart
@@ -31,10 +31,10 @@ class MockBuildContext extends Mock implements BuildContext {}
 
 class MockUser extends Mock implements User {}
 
-Municipality m =
+Municipality municipality =
     Municipality(user: MockUser(), municipalityName: 'municipalityName');
 
-Report r = Report(
+Report report = Report(
     city: 'testCity',
     reportId: 'report123',
     priority: PriorityReport.high,
@@ -56,7 +56,7 @@ class FakeReportDAO extends Fake implements MunicipalityReportManagementDAO {
     required String? reportId,
     required StatusReport newStatus,
   }) async {
-    r.status = newStatus;
+    report.status = newStatus;
   }
 }
 
@@ -100,16 +100,16 @@ void _testState(
   const reportId = 'report123';
 
   testWidgets(description, (tester) async {
-    r.status = currentStatus;
+    report.status = currentStatus;
     // Costruisci un widget con un contesto reale
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
         body: Builder(builder: (context) {
           final controller = MunicipalityReportManagementController.forTest(
-            rdao: mockReportDAO,
-            udao: mockUserDAO,
+            reportDAO: mockReportDAO,
+            userDAO: mockUserDAO,
             context: context,
-            m: m,
+            municipality: municipality,
           );
 
           return ElevatedButton(
@@ -130,6 +130,6 @@ void _testState(
     await tester.tap(find.byType(ElevatedButton));
     await tester.pumpAndSettle();
 
-    expect(r.status, equals(expectedStatus));
+    expect(report.status, equals(expectedStatus));
   });
 }

--- a/src/test/status_change_test.dart
+++ b/src/test/status_change_test.dart
@@ -64,26 +64,43 @@ void main() {
   /// TC_7.0.1 invalid StatusReport Expected: changeStatus Fails
   // enum not valid is tested by enum itself
 
-  /// TC_7.0.2 StatusReport Scartata Expected: changeStatus Fails
+  /// TC_7.0.2 Transitions from 'completed' or 'rejected' are not allowed
   _testState(
       description:
-          'TC_7.0.2 StatusReport Scartata Expected: changeStatus Fails',
+          'TC_7.0.2 StatusReport from Scartata to other Expected: changeStatus Fails',
       currentStatus: StatusReport.rejected,
       newStatus: StatusReport.inProgress,
       expectedStatus: StatusReport.rejected);
 
-  /// TC_7.0.3 StatusReport current After new Expected: changeStatus Fails
+  /// TC_7.0.3 transition from state not 'in attesa' to 'scartata' to  Expected: changeStatus Fails
   _testState(
       description:
-          'TC_7.0.3 StatusReport current After new Expected: changeStatus Fails',
+          'TC_7.0.3 StatusReport from not in Attesa to Scartata Expected: changeStatus Fails',
+      currentStatus: StatusReport.inProgress,
+      newStatus: StatusReport.rejected,
+      expectedStatus: StatusReport.rejected);
+
+  /// TC_7.0.4 transition to previus state Expected: changeStatus Fails
+  _testState(
+      description:
+          'TC_7.0.4 StatusReport previous state Expected: changeStatus Fails',
       currentStatus: StatusReport.completed,
       newStatus: StatusReport.inProgress,
       expectedStatus: StatusReport.completed);
 
-  /// TC_7.0.4 StatusReport current Before new and valid Expected: changeStatus is Accepted
+  /// TC_7.0.5 transition non respecting correct order Expected: changeStatus is Fails
   _testState(
       description:
-          'TC_7.0.3 StatusReport current After new Expected: changeStatus Fails',
+          'TC_7.0.4 StatusReport not respecting order Expected: changeStatus is Fails',
+      currentStatus: StatusReport.accepted,
+      newStatus: StatusReport.completed,
+      expectedStatus: StatusReport.accepted);
+
+
+  /// TC_7.0.6 The current status in the StatusReport precedes the new status, adhering to the correct order Expected: changeStatus is Accepted
+  _testState(
+      description:
+          'TC_7.0.3 StatusReport correct order new Expected: changeStatus Fails',
       currentStatus: StatusReport.inProgress,
       newStatus: StatusReport.completed,
       expectedStatus: StatusReport.completed);


### PR DESCRIPTION
This pull request introduces several changes to the `gestione_segnalazione_comune` module to enhance the status management of reports. The changes include modifying the status transition logic, updating the controller to handle new parameters, and adding tests for the new status change rules.

### Status Management Enhancements:

* [`src/lib/gestione_segnalazione_comune/dettagli_segnalazione_comune_gui.dart`](diffhunk://#diff-e9eea0e84133c414dec1af4c2d462ef338f24b04efae4989f9b6ec46b34af302L24-R42): Updated the `_filteredStatusValues` method to return specific next statuses instead of sublists, and modified `_saveReportState` to accept the old status as a parameter. [[1]](diffhunk://#diff-e9eea0e84133c414dec1af4c2d462ef338f24b04efae4989f9b6ec46b34af302L24-R42) [[2]](diffhunk://#diff-e9eea0e84133c414dec1af4c2d462ef338f24b04efae4989f9b6ec46b34af302R115-R116) [[3]](diffhunk://#diff-e9eea0e84133c414dec1af4c2d462ef338f24b04efae4989f9b6ec46b34af302L133) [[4]](diffhunk://#diff-e9eea0e84133c414dec1af4c2d462ef338f24b04efae4989f9b6ec46b34af302L148-R155)

### Controller Updates:

* [`src/lib/gestione_segnalazione_comune/gestione_segnalazione_comune_controller.dart`](diffhunk://#diff-baca7b9053e316539b9fa57db40b4446aa7b969f5480d5c460e19d80b8c7fd83L43-R79): Refactored the `MunicipalityReportManagementController` to take DAOs as parameters and added a new constructor for testing. Introduced the `isValidStatusChange` method to validate status transitions. [[1]](diffhunk://#diff-baca7b9053e316539b9fa57db40b4446aa7b969f5480d5c460e19d80b8c7fd83L43-R79) [[2]](diffhunk://#diff-baca7b9053e316539b9fa57db40b4446aa7b969f5480d5c460e19d80b8c7fd83R106-R162)

### Testing:

* [`src/test/status_change_test.dart`](diffhunk://#diff-46e23def3936cc6c3a127f8cb123a9e6ab75457645fa899be883fada31feaa8aR1-R151): Added comprehensive tests for the status change logic, including scenarios for invalid transitions and valid transitions following the correct order.