### PR TITLE
Test Filter Citizen

### DIFF
--- a/src/lib/gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart
+++ b/src/lib/gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart
@@ -427,7 +427,7 @@ class _ReportsListCitizenState extends State<ReportsViewCitizenGUI> {
                   },
                   onSubmitted: (value) {
                     if(value.length >255) { //prova
-                      _errorText='Lunghezza comune inferiore a 255';
+                      _errorText='Lunghezza search deve essere inferiore a 255';
                     }
                     if (value.isNotEmpty || _numberOfFilters > 0) {
                       _filterData(

--- a/src/lib/gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart
+++ b/src/lib/gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart
@@ -383,6 +383,7 @@ class _ReportsListCitizenState extends State<ReportsViewCitizenGUI> {
   /// The search icon does not have any functionality implemented yet.
   Widget _searchBar() {
     return Padding(
+
       padding: const EdgeInsets.all(10.0),
       child: Card(
         color: Colors.white70,
@@ -425,6 +426,9 @@ class _ReportsListCitizenState extends State<ReportsViewCitizenGUI> {
                     _keyWords = value;
                   },
                   onSubmitted: (value) {
+                    if(value.length >255) { //prova
+                      _errorText='Lunghezza comune inferiore a 255';
+                    }
                     if (value.isNotEmpty || _numberOfFilters > 0) {
                       _filterData(
                           city: _citizen?.city ?? '', keyWords: _keyWords);

--- a/src/test/filtro_test.dart
+++ b/src/test/filtro_test.dart
@@ -1,26 +1,56 @@
+import 'package:civiconnect/model/report_model.dart';
+import 'package:civiconnect/utils/report_status_priority.dart';
+import 'package:civiconnect/widgets/filter_modal.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:form_builder_validators/form_builder_validators.dart';
+//import 'package:form_builder_validators/form_builder_validators.dart';
+
+/// TC_6.0_1
+/// VC1
+/// Errore: Categoria non valida
+/// TC_6.0_2
+/// VC2 FD1
+/// Errore: Formato data non valido
+/// TC_6.0_3
+/// VC2 FD2 VD1
+/// Errore: Data non valida
+/// TC_6.0_4
+/// VC2 FD2 VD2 VP1
+/// Errore: Priorità non valida
+/// TC_6.0_5
+/// VC2 FD2 VS2 VP2 VS1
+/// Errore: Stato non valido
+/// TC_6.0_6
+/// VC2 FD2 VS2 VP2 VS2 L1
+/// Errore: Lunghezza non corretta
+/// TC_6.0_7
+/// VC2 FD2 VS2 VP2 VS2 L2
+/// Corretto
+
+
+
+
+
+
 
 void main() {
   // Inizializza il binding per i test Flutter
   TestWidgetsFlutterBinding.ensureInitialized();
 
   // Esegui i test
-  _testComune(description: "TC_6.0_1",input: "a"*300, expected: "Lunghezza comune inferiore a 255",reason: "Il campo comune deve rispettare la lunghezza massima di 255 caratteri");
-  _testComune(description: "TC_6.0_1",input: "a",expected: null,reason: "Il campo comune ha lungezza minore di 255 caratteri");
+  //_testComune(description: "TC_6.0_1",input: "a"*300, expected: "Lunghezza comune inferiore a 255",reason: "Il campo comune deve rispettare la lunghezza massima di 255 caratteri");
+ // _testComune(description: "TC_6.0_2",input: "a",expected: null,reason: "Il campo comune ha lungezza minore di 255 caratteri");
 
-  _testData(
-      description: 'Test Date Range Picker with valid dates',
-      input1: '2024-12-10T12:30:00.000Z',
-      input2: '2024-12-11T12:30:00.000Z',
-      expected: 'Intervallo non valido',
-      reason: 'Intervallo non esistente',
-  );
+  _testForm(description: 'TC_6.0_1', status: StatusReport.accepted , priority:PriorityReport.medium , category: Category.values[8], data: DateTime.now(), expected: 'Errore Categoria non valida', reason: 'Categoria non valida');
+  /*_testForm(description: 'TC_6.0_2', status: status, priority: priority, category: category, data: data, expected: expected, reason: reason);
+  _testForm(description: 'TC_6.0_3', status: status, priority: priority, category: category, data: data, expected: expected, reason: reason);
+  _testForm(description: 'TC_6.0_4', status: status, priority: priority, category: category, data: data, expected: expected, reason: reason);
+  _testForm(description: 'TC_6.0_5', status: status, priority: priority, category: category, data: data, expected: expected, reason: reason);
+  _testForm(description: 'TC_6.0_6', status: status, priority: priority, category: category, data: data, expected: expected, reason: reason);
+  _testForm(description: 'TC_6.0_7', status: status, priority: priority, category: category, data: data, expected: expected, reason: reason);*/
 }
-
+/*
 void _testComune({required String description,required String input,required String? expected,required String reason}) {
   testWidgets(description, (WidgetTester tester) async {
     final key = GlobalKey<FormBuilderFieldState>();
@@ -60,187 +90,81 @@ void _testComune({required String description,required String input,required Str
 
 
   });
-}
-/*
-void _testDatePicker({required String description, required String input1 , required String input2, required String? expected, required String reason}) {
-  testWidgets(description, (WidgetTester tester) async {
-    // Definizione dell'intervallo iniziale selezionato
-    DateTimeRange? selectedDate;
-      DateTime? a = DateTime.tryParse(input1);
-      DateTime? b = DateTime.tryParse(input2);
-      print(a);
-      print(b);
-      if(a==null || b==null){
-        print("Data non valida");
-        expect(a, isNull, reason: 'La data deve essere in un formato valido.');
-        expect(b, isNull, reason: 'La data deve essere in un formato valido.');
-        return;
-      }
-
-    // Metodo che simula il DatePickerDialog
-    Future<DateTimeRange?> _datePickerDialog(BuildContext context) {
-      return showDateRangePicker(
-        context: context,
-        firstDate: DateTime(2023),
-        lastDate: DateTime.now(),
-        confirmText: 'Conferma',
-        errorInvalidRangeText: 'Intervallo non valido',
-        errorFormatText: 'Formato non valido',
-        fieldStartHintText: 'Inizio',
-        fieldEndHintText: 'Fine',
-        currentDate: DateTime.now(),
-        initialDateRange: DateTimeRange(start: a, end: b),
-        locale: const Locale('it', 'IT'),
-        helpText: 'Seleziona un intervallo di date',
-        builder: (context, child) {
-          return Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              Container(
-                decoration: BoxDecoration(
-                  color: Colors.white,
-                  borderRadius: BorderRadius.circular(10),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.grey.withOpacity(0.5),
-                      blurRadius: 10,
-                      offset: const Offset(0, 3),
-                    ),
-                  ],
-                ),
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(10),
-                  child: ConstrainedBox(
-                    constraints: const BoxConstraints(
-                      maxWidth: 300, // Imposta un limite alla larghezza
-                      maxHeight: 400, // Imposta un limite all'altezza
-                    ),
-                    child: child,
-                  ),
-                ),
-              ),
-            ],
-          );
-        },
-      );
-    }
-
-    // Widget con il pulsante che apre il DatePickerDialog
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: Builder(
-            builder: (context) {
-              return ElevatedButton(
-                onPressed: () async {
-                  selectedDate = await _datePickerDialog(context);
-                },
-                child: const Text('Apri Date Picker'),
-              );
-            },
-          ),
-        ),
-      ),
-    );
-      
-      print("selectedDate"+ selectedDate.toString());
-    print("to local");
-    print(a.toLocal());
-    print(b.toLocal());
+}*/
 
 
-    // Trova il pulsante e simula un tap per aprire il DatePickerDialog
-    final button = find.byType(ElevatedButton);
-    expect(button, findsOneWidget, reason: 'Il pulsante deve essere presente nel widget tree.');
-    await tester.tap(button);
-
-    // Ricostruisci il widget tree per mostrare il dialog
-    await tester.pumpAndSettle();
-
-    // Trova i campi del DatePicker
-    final startHint = find.text('Inizio');
-    final endHint = find.text('Fine');
-    final confirmButton = find.text('Conferma');
-
-    expect(startHint, findsOneWidget, reason: 'Il campo di inizio deve essere visibile.');
-    expect(endHint, findsOneWidget, reason: 'Il campo di fine deve essere visibile.');
-    expect(confirmButton, findsOneWidget, reason: 'Il pulsante di conferma deve essere visibile.');
-
-    // Simula un tap su "Conferma" senza selezionare un range valido
-    await tester.tap(confirmButton);
-    await tester.pumpAndSettle();
-
-    if (a.isAfter(b)) {
-      final errorMessage = find.text('Intervallo non valido');
-      expect(errorMessage, findsOneWidget, reason: reason);
-    }
-
-    // Trova il messaggio di errore
-    final errorMessage = find.text('Intervallo non valido');
-    expect(expected, findsOneWidget, reason: reason);
-  });
-}
-
-
- */
-
-void _testData({
+void _testForm({
   required String description,
-  required String input1,
-  required String input2,
+  required StatusReport status,
+  required PriorityReport priority,
+  required Category category,
+  required DateTime data,
   required String? expected,
   required String reason,
 }) {
-  testWidgets(description, (WidgetTester tester) async {
+  testWidgets('FilterModal should display correctly and handle interactions',
+          (WidgetTester tester) async {
+        // Mock callbacks
+        bool onSubmitCalled = false;
 
-    // Impostazione delle date
-    DateTime firstDate = DateTime(2020);
-    DateTime lastDate = DateTime(2100);
 
-    // Stampa dei valori di firstDate e lastDate
-    print('First Date: $firstDate');
-    print('Last Date: $lastDate');
 
-    // Creazione del widget con DateRangePickerDialog
-    Widget createDateRangePickerDialogWidget() {
-      return MaterialApp(
-        localizationsDelegates: const [
-          GlobalMaterialLocalizations.delegate,
-          GlobalWidgetsLocalizations.delegate,
-        ],
-        supportedLocales: const [Locale('en', 'US')],
-        home: Scaffold(
-          body: Center(
-            child: DateRangePickerDialog(
-              initialDateRange: DateTimeRange(
-                start: DateTime.parse(input1),
-                end: DateTime.parse(input2),
+        // Costruzione del widget con dati di esempio
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: FilterModal(
+                onSubmit: ({
+                  required String city,
+                  List<StatusReport>? status,
+                  List<PriorityReport>? priority,
+                  List<Category>? category,
+                  DateTimeRange? dateRange,
+                  bool? isCityEnabled,
+                  bool? popNav,
+                }) {
+                  onSubmitCalled = true;
+                },
+                onReset: () {
+                },
+                startCity: 'Salerno',
+                isCityEnabled: true,
+                statusCriteria: const [StatusReport.inProgress],
+                priorityCriteria: const [PriorityReport.high],
+                categoryCriteria:  [Category.values[8]],
+                defaultCity: 'Salerno',
+                dateRange: DateTimeRange(
+                  start: DateTime(2023, 01, 01),
+                  end: DateTime(2023, 12, 31),
+                ),
               ),
-              firstDate: firstDate,
-              lastDate: lastDate,
             ),
           ),
-        ),
-      );
-    }
+        );
 
-    // Eseguiamo il widget di test
-    await tester.pumpWidget(createDateRangePickerDialogWidget());
-    await tester.pumpAndSettle(); // Assicura che il widget si sia caricato completamente
 
-    // Verifica che il DateRangePickerDialog sia presente
-    expect(find.byType(DateRangePickerDialog), findsOneWidget);
 
-    // Verifica il testo che ti aspetti come "expected"
-    if (expected != null) {
-      expect(find.text(expected), findsOneWidget);
-    }
 
-    // Puoi anche aggiungere altre asserzioni, come la verifica dei valori di data
-    print('Inizio: $input1, Fine: $input2');
-  });
+
+
+            await tester.ensureVisible(find.byType(FormBuilderTextField));
+            await tester.enterText(find.byType(FormBuilderTextField), 'BLITZ');
+
+
+            await tester.ensureVisible(find.text('Filtra'));
+            await tester.tap(find.text('Filtra'));
+            await tester.pump();
+
+
+
+            expect(onSubmitCalled, false);
+
+
+      
+
+      });
 }
+
 
 
 

--- a/src/test/filtro_test.dart
+++ b/src/test/filtro_test.dart
@@ -3,6 +3,8 @@ import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:form_builder_validators/form_builder_validators.dart';
 //import 'package:form_builder_validators/form_builder_validators.dart';
+
+
 /// | **Test Case ID** | **Test Frame**          | **Esito**                         |
 /// |------------------|-------------------------|------------------------------------|
 /// | TC_6.0_1         | VC1                     | Errore: Categoria non valida      | enum is tested by the enum itself
@@ -12,9 +14,10 @@ import 'package:form_builder_validators/form_builder_validators.dart';
 /// | TC_6.0_5         | VC2 FD2 VS2 VP2 VS1     | Errore: Stato non valido          | enum is tested by the enum itself
 /// | TC_6.0_6         | VC2 FD2 VS2 VP2 VS2     | Corretto                          |
 /// | TC_6.0_7         | LR1                     | Errore: Lunghezza ricerca non corretta    |
-/// | TC_6.0_8         | LA1                     | Errore: Lunghezza Comune non corretta |
-/// | TC_6.0_9         | LA2                     | Corretto                          |
-/// | TC_6.0_10        | VC2 FD2 VS2 VP2 VS2     | Corretto                          |
+/// | TC_6.0_8         | LR2                    | Corretto                           |
+/// | TC_6.0_9         | LA1                     | Errore: Lunghezza Comune non corretta |
+/// | TC_6.0_10         | LA2                     | Corretto                          |
+/// | TC_6.0_11        | VC2 FD2 VS2 VP2 VS2     | Corretto                          |
 
 
 
@@ -24,9 +27,10 @@ void main() {
   // Inizializza il binding per i test Flutter
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  // Esegui i test
- _testComune(description: "TC_6.0_8",input: "a"*300, expected: "Lunghezza comune inferiore a 255",reason: "Il campo comune deve rispettare la lunghezza massima di 255 caratteri");
- _testComune(description: "TC_6.0_9",input: "a",expected: null,reason: "Il campo comune ha lungezza minore di 255 caratteri");
+  _testSearch(description: 'TC_6.0_7', input: 'a'*300, expected: 'Lunghezza search deve essere inferiore a 255', reason: 'Il campo search deve rispettare la lunghezza massima di 255 caratteri');
+  _testSearch(description: 'TC_6.0_8', input: 'a'*254, expected: '', reason: 'Il campo search ha lungezza minore di 255 caratteri');
+ _testComune(description: 'TC_6.0_9',input: 'a'*300, expected: 'Lunghezza comune deve essere inferiore a 255',reason: 'Il campo comune deve rispettare la lunghezza massima di 255 caratteri');
+ _testComune(description: 'TC_6.0_10',input: 'a',expected: null,reason: 'Il campo comune ha lungezza minore di 255 caratteri');
   /*
   _testForm(description: 'TC_6.0_1', status: StatusReport.accepted , priority:PriorityReport.medium , category: Category.values[8], data: DateTime.now(), expected: 'Errore Categoria non valida', reason: 'Categoria non valida');
  _testForm(description: 'TC_6.0_2', status: StatusReport.accepted, priority: PriorityReport.medium , category: Category.roadDamage, data: DateTime.parse("2022-10-11"), expected: 'Errore Formato data non valido', reason: '');
@@ -37,8 +41,7 @@ void main() {
   _testForm(description: 'TC_6.0_7', status: StatusReport.accepted, priority: PriorityReport.medium, category: Category.roadDamage, data: DateTime.now(), expected: null, reason: 'Corretto');
 _
 */
-  _testSearch(description: 'TC_6.0_7', input: 'a'*300, expected: 'Lunghezza search inferiore a 255', reason: 'Il campo search deve rispettare la lunghezza massima di 255 caratteri');
-  _testSearch(description: 'TC_6.0_7', input: 'a', expected: null, reason: 'corretto');
+
 }
 void _testComune({required String description,required String input,required String? expected,required String reason}) {
   testWidgets(description, (WidgetTester tester) async {
@@ -55,7 +58,7 @@ void _testComune({required String description,required String input,required Str
               initialValue: input, // Valore iniziale valido
               validator: FormBuilderValidators.maxLength(
                 255,
-                errorText: 'Lunghezza comune inferiore a 255',
+                errorText: 'Lunghezza comune deve essere inferiore a 255',
               ),
             ),
           ),
@@ -67,11 +70,18 @@ void _testComune({required String description,required String input,required Str
     final comuneField = find.byType(FormBuilderTextField);
     expect(comuneField, findsOneWidget,
         reason: 'Il campo comune deve essere presente nel widget tree.');
-    print(input);
-    print(comuneField.hasFound);
+    //print(input);
+    //print(comuneField.hasFound);
 
     // Esegui la validazione del campo
-    print(key.currentState?.validate());
+   key.currentState?.validate();
+    String error_text= 'null';
+    if(expected==null){
+      print(description + ":" + "expected:"+" "+error_text + " "+ "reason:" +" "+ reason);
+    }
+    else{
+      print(description + ":" + "expected:"+""+ expected + " "+ "reason:" +" "+ reason);
+    }
 
     // Verifica che l'errore sia quello atteso
     expect(key.currentState?.errorText, expected,
@@ -83,7 +93,7 @@ void _testComune({required String description,required String input,required Str
 void _testSearch({required String description,required String input,required String? expected,required String reason}) {
   testWidgets(description, (WidgetTester tester) async {
     // Crea il widget da testare
-    final key = GlobalKey<FormBuilderFieldState>();
+
     String errorText = '';
     await tester.pumpWidget(
       MaterialApp(
@@ -120,7 +130,7 @@ void _testSearch({required String description,required String input,required Str
         ),
       ),
     );
-    print("Stampa dell input"+input);
+    //print("Stampa dell input" +input);
 
     // Trova il TextField e inserisci il testo lungo
     await tester.enterText(find.byType(TextField), input);
@@ -128,9 +138,11 @@ void _testSearch({required String description,required String input,required Str
     // Simula l'invio del testo
     await tester.testTextInput.receiveAction(TextInputAction.done);
     await tester.pump();
-    print(key.currentState?.validate());
+
     // Verifica il risultato
     expect(errorText, expected, reason: reason);
+
+    print(description + ":" + "expected:"+" "+ errorText + " "+"reason:" + reason);
   });
 }
 

--- a/src/test/filtro_test.dart
+++ b/src/test/filtro_test.dart
@@ -9,8 +9,9 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   // Esegui i test
-  _testCategoria(description: "TC_6.0_1",input: "a"*300, expected: "Lunghezza comune inferiore a 255",reason: "Il campo comune deve rispettare la lunghezza massima di 255 caratteri");
-  _testCategoria(description: "TC_6.0_1",input: "a",expected: null,reason: "Il campo comune ha lungezza minore di 255 caratteri");
+  _testComune(description: "TC_6.0_1",input: "a"*300, expected: "Lunghezza comune inferiore a 255",reason: "Il campo comune deve rispettare la lunghezza massima di 255 caratteri");
+  _testComune(description: "TC_6.0_1",input: "a",expected: null,reason: "Il campo comune ha lungezza minore di 255 caratteri");
+
   _testData(
       description: 'Test Date Range Picker with valid dates',
       input1: '2024-12-10T12:30:00.000Z',
@@ -20,7 +21,7 @@ void main() {
   );
 }
 
-void _testCategoria({required String description,required String input,required String? expected,required String reason}) {
+void _testComune({required String description,required String input,required String? expected,required String reason}) {
   testWidgets(description, (WidgetTester tester) async {
     final key = GlobalKey<FormBuilderFieldState>();
 

--- a/src/test/filtro_test.dart
+++ b/src/test/filtro_test.dart
@@ -25,7 +25,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   // Esegui i test
-  _testComune(description: "TC_6.0_8",input: "a"*300, expected: "Lunghezza comune inferiore a 255",reason: "Il campo comune deve rispettare la lunghezza massima di 255 caratteri");
+ _testComune(description: "TC_6.0_8",input: "a"*300, expected: "Lunghezza comune inferiore a 255",reason: "Il campo comune deve rispettare la lunghezza massima di 255 caratteri");
  _testComune(description: "TC_6.0_9",input: "a",expected: null,reason: "Il campo comune ha lungezza minore di 255 caratteri");
   /*
   _testForm(description: 'TC_6.0_1', status: StatusReport.accepted , priority:PriorityReport.medium , category: Category.values[8], data: DateTime.now(), expected: 'Errore Categoria non valida', reason: 'Categoria non valida');
@@ -35,8 +35,10 @@ void main() {
   _testForm(description: 'TC_6.0_5', status:  StatusReport.values[10], priority: PriorityReport.medium, category: Category.roadDamage, data: DateTime.now(), expected: 'Errore Stato non valido', reason: 'Stato non valido');
   _testForm(description: 'TC_6.0_6', status: StatusReport.accepted, priority: PriorityReport.medium, category: Category.roadDamage, data: DateTime.now(), expected: null, reason: 'Corretto');
   _testForm(description: 'TC_6.0_7', status: StatusReport.accepted, priority: PriorityReport.medium, category: Category.roadDamage, data: DateTime.now(), expected: null, reason: 'Corretto');
-
+_
 */
+  _testSearch(description: 'TC_6.0_7', input: 'a'*300, expected: 'Lunghezza search inferiore a 255', reason: 'Il campo search deve rispettare la lunghezza massima di 255 caratteri');
+  _testSearch(description: 'TC_6.0_7', input: 'a', expected: null, reason: 'corretto');
 }
 void _testComune({required String description,required String input,required String? expected,required String reason}) {
   testWidgets(description, (WidgetTester tester) async {
@@ -76,6 +78,59 @@ void _testComune({required String description,required String input,required Str
         reason: reason);
 
 
+  });
+}
+void _testSearch({required String description,required String input,required String? expected,required String reason}) {
+  testWidgets(description, (WidgetTester tester) async {
+    // Crea il widget da testare
+    final key = GlobalKey<FormBuilderFieldState>();
+    String errorText = '';
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Padding(
+            padding: const EdgeInsets.all(10.0),
+            child: Card(
+              color: Colors.white70,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+              elevation: 2,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 5, horizontal: 5),
+                child: Row(
+                  children: [
+                    Flexible(
+                      child: TextField(
+                        onSubmitted: (value) {
+                          if (value.length > 255) {
+                            errorText = expected!;
+                          }
+                        },
+                        decoration: const InputDecoration(
+                          hintText: 'Cerca segnalazione...',
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    print("Stampa dell input"+input);
+
+    // Trova il TextField e inserisci il testo lungo
+    await tester.enterText(find.byType(TextField), input);
+
+    // Simula l'invio del testo
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pump();
+    print(key.currentState?.validate());
+    // Verifica il risultato
+    expect(errorText, expected, reason: reason);
   });
 }
 

--- a/src/test/filtro_test.dart
+++ b/src/test/filtro_test.dart
@@ -1,0 +1,245 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:form_builder_validators/form_builder_validators.dart';
+
+void main() {
+  // Inizializza il binding per i test Flutter
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // Esegui i test
+  _testCategoria(description: "TC_6.0_1",input: "a"*300, expected: "Lunghezza comune inferiore a 255",reason: "Il campo comune deve rispettare la lunghezza massima di 255 caratteri");
+  _testCategoria(description: "TC_6.0_1",input: "a",expected: null,reason: "Il campo comune ha lungezza minore di 255 caratteri");
+  _testData(
+      description: 'Test Date Range Picker with valid dates',
+      input1: '2024-12-10T12:30:00.000Z',
+      input2: '2024-12-11T12:30:00.000Z',
+      expected: 'Intervallo non valido',
+      reason: 'Intervallo non esistente',
+  );
+}
+
+void _testCategoria({required String description,required String input,required String? expected,required String reason}) {
+  testWidgets(description, (WidgetTester tester) async {
+    final key = GlobalKey<FormBuilderFieldState>();
+
+    // Renderizza il widget contenente il campo FormBuilderTextField
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: FormBuilder(
+            child: FormBuilderTextField(
+              name: 'comune',
+              key: key,
+              initialValue: input, // Valore iniziale valido
+              validator: FormBuilderValidators.maxLength(
+                255,
+                errorText: 'Lunghezza comune inferiore a 255',
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Trova il campo "comune"
+    final comuneField = find.byType(FormBuilderTextField);
+    expect(comuneField, findsOneWidget,
+        reason: 'Il campo comune deve essere presente nel widget tree.');
+    print(input);
+    print(comuneField.hasFound);
+
+    // Esegui la validazione del campo
+    print(key.currentState?.validate());
+
+    // Verifica che l'errore sia quello atteso
+    expect(key.currentState?.errorText, expected,
+        reason: reason);
+
+
+  });
+}
+/*
+void _testDatePicker({required String description, required String input1 , required String input2, required String? expected, required String reason}) {
+  testWidgets(description, (WidgetTester tester) async {
+    // Definizione dell'intervallo iniziale selezionato
+    DateTimeRange? selectedDate;
+      DateTime? a = DateTime.tryParse(input1);
+      DateTime? b = DateTime.tryParse(input2);
+      print(a);
+      print(b);
+      if(a==null || b==null){
+        print("Data non valida");
+        expect(a, isNull, reason: 'La data deve essere in un formato valido.');
+        expect(b, isNull, reason: 'La data deve essere in un formato valido.');
+        return;
+      }
+
+    // Metodo che simula il DatePickerDialog
+    Future<DateTimeRange?> _datePickerDialog(BuildContext context) {
+      return showDateRangePicker(
+        context: context,
+        firstDate: DateTime(2023),
+        lastDate: DateTime.now(),
+        confirmText: 'Conferma',
+        errorInvalidRangeText: 'Intervallo non valido',
+        errorFormatText: 'Formato non valido',
+        fieldStartHintText: 'Inizio',
+        fieldEndHintText: 'Fine',
+        currentDate: DateTime.now(),
+        initialDateRange: DateTimeRange(start: a, end: b),
+        locale: const Locale('it', 'IT'),
+        helpText: 'Seleziona un intervallo di date',
+        builder: (context, child) {
+          return Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Container(
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(10),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.grey.withOpacity(0.5),
+                      blurRadius: 10,
+                      offset: const Offset(0, 3),
+                    ),
+                  ],
+                ),
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(10),
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(
+                      maxWidth: 300, // Imposta un limite alla larghezza
+                      maxHeight: 400, // Imposta un limite all'altezza
+                    ),
+                    child: child,
+                  ),
+                ),
+              ),
+            ],
+          );
+        },
+      );
+    }
+
+    // Widget con il pulsante che apre il DatePickerDialog
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) {
+              return ElevatedButton(
+                onPressed: () async {
+                  selectedDate = await _datePickerDialog(context);
+                },
+                child: const Text('Apri Date Picker'),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+      
+      print("selectedDate"+ selectedDate.toString());
+    print("to local");
+    print(a.toLocal());
+    print(b.toLocal());
+
+
+    // Trova il pulsante e simula un tap per aprire il DatePickerDialog
+    final button = find.byType(ElevatedButton);
+    expect(button, findsOneWidget, reason: 'Il pulsante deve essere presente nel widget tree.');
+    await tester.tap(button);
+
+    // Ricostruisci il widget tree per mostrare il dialog
+    await tester.pumpAndSettle();
+
+    // Trova i campi del DatePicker
+    final startHint = find.text('Inizio');
+    final endHint = find.text('Fine');
+    final confirmButton = find.text('Conferma');
+
+    expect(startHint, findsOneWidget, reason: 'Il campo di inizio deve essere visibile.');
+    expect(endHint, findsOneWidget, reason: 'Il campo di fine deve essere visibile.');
+    expect(confirmButton, findsOneWidget, reason: 'Il pulsante di conferma deve essere visibile.');
+
+    // Simula un tap su "Conferma" senza selezionare un range valido
+    await tester.tap(confirmButton);
+    await tester.pumpAndSettle();
+
+    if (a.isAfter(b)) {
+      final errorMessage = find.text('Intervallo non valido');
+      expect(errorMessage, findsOneWidget, reason: reason);
+    }
+
+    // Trova il messaggio di errore
+    final errorMessage = find.text('Intervallo non valido');
+    expect(expected, findsOneWidget, reason: reason);
+  });
+}
+
+
+ */
+
+void _testData({
+  required String description,
+  required String input1,
+  required String input2,
+  required String? expected,
+  required String reason,
+}) {
+  testWidgets(description, (WidgetTester tester) async {
+
+    // Impostazione delle date
+    DateTime firstDate = DateTime(2020);
+    DateTime lastDate = DateTime(2100);
+
+    // Stampa dei valori di firstDate e lastDate
+    print('First Date: $firstDate');
+    print('Last Date: $lastDate');
+
+    // Creazione del widget con DateRangePickerDialog
+    Widget createDateRangePickerDialogWidget() {
+      return MaterialApp(
+        localizationsDelegates: const [
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+        ],
+        supportedLocales: const [Locale('en', 'US')],
+        home: Scaffold(
+          body: Center(
+            child: DateRangePickerDialog(
+              initialDateRange: DateTimeRange(
+                start: DateTime.parse(input1),
+                end: DateTime.parse(input2),
+              ),
+              firstDate: firstDate,
+              lastDate: lastDate,
+            ),
+          ),
+        ),
+      );
+    }
+
+    // Eseguiamo il widget di test
+    await tester.pumpWidget(createDateRangePickerDialogWidget());
+    await tester.pumpAndSettle(); // Assicura che il widget si sia caricato completamente
+
+    // Verifica che il DateRangePickerDialog sia presente
+    expect(find.byType(DateRangePickerDialog), findsOneWidget);
+
+    // Verifica il testo che ti aspetti come "expected"
+    if (expected != null) {
+      expect(find.text(expected), findsOneWidget);
+    }
+
+    // Puoi anche aggiungere altre asserzioni, come la verifica dei valori di data
+    print('Inizio: $input1, Fine: $input2');
+  });
+}
+
+
+

--- a/src/test/filtro_test.dart
+++ b/src/test/filtro_test.dart
@@ -5,21 +5,19 @@ import 'package:form_builder_validators/form_builder_validators.dart';
 //import 'package:form_builder_validators/form_builder_validators.dart';
 
 
-/// | **Test Case ID** | **Test Frame**          | **Esito**                         |
+/// | **Test Case ID** | **Test Frame**          | **Outcome**                       |
 /// |------------------|-------------------------|------------------------------------|
-/// | TC_6.0_1         | VC1                     | Errore: Categoria non valida      | enum is tested by the enum itself
-/// | TC_6.0_2         | VC2 FD1                 | Errore: Formato data non valido   | enum is tested by the enum itself
-/// | TC_6.0_3         | VC2 FD2 VD1             | Errore: Data non valida           | enum is tested by the enum itself
-/// | TC_6.0_4         | VC2 FD2 VD2 VP1         | Errore: Priorità non valida       | enum is tested by the enum itself
-/// | TC_6.0_5         | VC2 FD2 VS2 VP2 VS1     | Errore: Stato non valido          | enum is tested by the enum itself
-/// | TC_6.0_6         | VC2 FD2 VS2 VP2 VS2     | Corretto                          |
-/// | TC_6.0_7         | LR1                     | Errore: Lunghezza ricerca non corretta    |
-/// | TC_6.0_8         | LR2                    | Corretto                           |
-/// | TC_6.0_9         | LA1                     | Errore: Lunghezza Comune non corretta |
-/// | TC_6.0_10         | LA2                     | Corretto                          |
-/// | TC_6.0_11        | VC2 FD2 VS2 VP2 VS2     | Corretto                          |
-
-
+/// | TC_6.0_1         | VC1                     | Error: Category is not valid      | enum is tested by the enum itself
+/// | TC_6.0_2         | VC2 FD1                 | Error: Invalid date format        | enum is tested by the enum itself
+/// | TC_6.0_3         | VC2 FD2 VD1             | Error: Invalid date               | enum is tested by the enum itself
+/// | TC_6.0_4         | VC2 FD2 VD2 VP1         | Error: Invalid priority           | enum is tested by the enum itself
+/// | TC_6.0_5         | VC2 FD2 VS2 VP2 VS1     | Error: Invalid status             | enum is tested by the enum itself
+/// | TC_6.0_6         | VC2 FD2 VS2 VP2 VS2     | Correct                           |
+/// | TC_6.0_7         | LR1                     | Error: Incorrect search length    |
+/// | TC_6.0_8         | LR2                     | Correct                           |
+/// | TC_6.0_9         | LA1                     | Error: Incorrect city length      |
+/// | TC_6.0_10        | LA2                     | Correct                           |
+/// | TC_6.0_11        | VC2 FD2 VS2 VP2 VS2     | Correct                           |
 
 
 
@@ -31,6 +29,9 @@ void main() {
   _testSearch(description: 'TC_6.0_8', input: 'a'*254, expected: '', reason: 'Il campo search ha lungezza minore di 255 caratteri');
  _testComune(description: 'TC_6.0_9',input: 'a'*300, expected: 'Lunghezza comune deve essere inferiore a 255',reason: 'Il campo comune deve rispettare la lunghezza massima di 255 caratteri');
  _testComune(description: 'TC_6.0_10',input: 'a',expected: null,reason: 'Il campo comune ha lungezza minore di 255 caratteri');
+
+
+ /// test with enums
   /*
   _testForm(description: 'TC_6.0_1', status: StatusReport.accepted , priority:PriorityReport.medium , category: Category.values[8], data: DateTime.now(), expected: 'Errore Categoria non valida', reason: 'Categoria non valida');
  _testForm(description: 'TC_6.0_2', status: StatusReport.accepted, priority: PriorityReport.medium , category: Category.roadDamage, data: DateTime.parse("2022-10-11"), expected: 'Errore Formato data non valido', reason: '');
@@ -38,13 +39,14 @@ void main() {
   _testForm(description: 'TC_6.0_4', status: StatusReport.accepted, priority: PriorityReport.values[10], category: Category.roadDamage, data: DateTime.now(), expected: 'Errore Priorità non valida', reason: 'Priorità non valida');
   _testForm(description: 'TC_6.0_5', status:  StatusReport.values[10], priority: PriorityReport.medium, category: Category.roadDamage, data: DateTime.now(), expected: 'Errore Stato non valido', reason: 'Stato non valido');
   _testForm(description: 'TC_6.0_6', status: StatusReport.accepted, priority: PriorityReport.medium, category: Category.roadDamage, data: DateTime.now(), expected: null, reason: 'Corretto');
-  _testForm(description: 'TC_6.0_7', status: StatusReport.accepted, priority: PriorityReport.medium, category: Category.roadDamage, data: DateTime.now(), expected: null, reason: 'Corretto');
+  _testForm(description: 'TC_6.0_11', status: StatusReport.accepted, priority: PriorityReport.medium, category: Category.roadDamage, data: DateTime.now(), expected: null, reason: 'Corretto');
 _
 */
 
 }
+/// Test for city field
 void _testComune({required String description,required String input,required String? expected,required String reason}) {
-  testWidgets(description, (WidgetTester tester) async {
+  testWidgets(description, (tester) async {
     final key = GlobalKey<FormBuilderFieldState>();
 
     // Renderizza il widget contenente il campo FormBuilderTextField
@@ -75,12 +77,12 @@ void _testComune({required String description,required String input,required Str
 
     // Esegui la validazione del campo
    key.currentState?.validate();
-    String error_text= 'null';
+    //String errorText= 'null';
     if(expected==null){
-      print(description + ":" + "expected:"+" "+error_text + " "+ "reason:" +" "+ reason);
+      //print('$description:expected: $errorText reason: $reason');
     }
     else{
-      print(description + ":" + "expected:"+""+ expected + " "+ "reason:" +" "+ reason);
+      //print('$description:expected:$expected reason: $reason');
     }
 
     // Verifica che l'errore sia quello atteso
@@ -90,8 +92,10 @@ void _testComune({required String description,required String input,required Str
 
   });
 }
+
+/// Test for search field
 void _testSearch({required String description,required String input,required String? expected,required String reason}) {
-  testWidgets(description, (WidgetTester tester) async {
+  testWidgets(description, (tester) async {
     // Crea il widget da testare
 
     String errorText = '';
@@ -142,10 +146,12 @@ void _testSearch({required String description,required String input,required Str
     // Verifica il risultato
     expect(errorText, expected, reason: reason);
 
-    print(description + ":" + "expected:"+" "+ errorText + " "+"reason:" + reason);
+    //print('$description:expected: $errorText reason:$reason');
   });
 }
 
+
+/// Test for all the field of the form
 /*
 void _testForm({
   required String description,

--- a/src/test/filtro_test.dart
+++ b/src/test/filtro_test.dart
@@ -1,34 +1,20 @@
-import 'package:civiconnect/model/report_model.dart';
-import 'package:civiconnect/utils/report_status_priority.dart';
-import 'package:civiconnect/widgets/filter_modal.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:form_builder_validators/form_builder_validators.dart';
 //import 'package:form_builder_validators/form_builder_validators.dart';
-
-/// TC_6.0_1
-/// VC1
-/// Errore: Categoria non valida
-/// TC_6.0_2
-/// VC2 FD1
-/// Errore: Formato data non valido
-/// TC_6.0_3
-/// VC2 FD2 VD1
-/// Errore: Data non valida
-/// TC_6.0_4
-/// VC2 FD2 VD2 VP1
-/// Errore: Priorità non valida
-/// TC_6.0_5
-/// VC2 FD2 VS2 VP2 VS1
-/// Errore: Stato non valido
-/// TC_6.0_6
-/// VC2 FD2 VS2 VP2 VS2 L1
-/// Errore: Lunghezza non corretta
-/// TC_6.0_7
-/// VC2 FD2 VS2 VP2 VS2 L2
-/// Corretto
-
-
+/// | **Test Case ID** | **Test Frame**          | **Esito**                         |
+/// |------------------|-------------------------|------------------------------------|
+/// | TC_6.0_1         | VC1                     | Errore: Categoria non valida      | enum is tested by the enum itself
+/// | TC_6.0_2         | VC2 FD1                 | Errore: Formato data non valido   | enum is tested by the enum itself
+/// | TC_6.0_3         | VC2 FD2 VD1             | Errore: Data non valida           | enum is tested by the enum itself
+/// | TC_6.0_4         | VC2 FD2 VD2 VP1         | Errore: Priorità non valida       | enum is tested by the enum itself
+/// | TC_6.0_5         | VC2 FD2 VS2 VP2 VS1     | Errore: Stato non valido          | enum is tested by the enum itself
+/// | TC_6.0_6         | VC2 FD2 VS2 VP2 VS2     | Corretto                          |
+/// | TC_6.0_7         | LR1                     | Errore: Lunghezza ricerca non corretta    |
+/// | TC_6.0_8         | LA1                     | Errore: Lunghezza Comune non corretta |
+/// | TC_6.0_9         | LA2                     | Corretto                          |
+/// | TC_6.0_10        | VC2 FD2 VS2 VP2 VS2     | Corretto                          |
 
 
 
@@ -39,18 +25,19 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   // Esegui i test
-  //_testComune(description: "TC_6.0_1",input: "a"*300, expected: "Lunghezza comune inferiore a 255",reason: "Il campo comune deve rispettare la lunghezza massima di 255 caratteri");
- // _testComune(description: "TC_6.0_2",input: "a",expected: null,reason: "Il campo comune ha lungezza minore di 255 caratteri");
-
+  _testComune(description: "TC_6.0_8",input: "a"*300, expected: "Lunghezza comune inferiore a 255",reason: "Il campo comune deve rispettare la lunghezza massima di 255 caratteri");
+ _testComune(description: "TC_6.0_9",input: "a",expected: null,reason: "Il campo comune ha lungezza minore di 255 caratteri");
+  /*
   _testForm(description: 'TC_6.0_1', status: StatusReport.accepted , priority:PriorityReport.medium , category: Category.values[8], data: DateTime.now(), expected: 'Errore Categoria non valida', reason: 'Categoria non valida');
-  /*_testForm(description: 'TC_6.0_2', status: status, priority: priority, category: category, data: data, expected: expected, reason: reason);
-  _testForm(description: 'TC_6.0_3', status: status, priority: priority, category: category, data: data, expected: expected, reason: reason);
-  _testForm(description: 'TC_6.0_4', status: status, priority: priority, category: category, data: data, expected: expected, reason: reason);
-  _testForm(description: 'TC_6.0_5', status: status, priority: priority, category: category, data: data, expected: expected, reason: reason);
-  _testForm(description: 'TC_6.0_6', status: status, priority: priority, category: category, data: data, expected: expected, reason: reason);
-  _testForm(description: 'TC_6.0_7', status: status, priority: priority, category: category, data: data, expected: expected, reason: reason);*/
+ _testForm(description: 'TC_6.0_2', status: StatusReport.accepted, priority: PriorityReport.medium , category: Category.roadDamage, data: DateTime.parse("2022-10-11"), expected: 'Errore Formato data non valido', reason: '');
+  _testForm(description: 'TC_6.0_3', status: StatusReport.accepted , priority:PriorityReport.medium , category: Category.roadDamage, data:DateTime.now().add(Duration(days: 1)), expected:'Errore Data non valida', reason: 'Data non valida');
+  _testForm(description: 'TC_6.0_4', status: StatusReport.accepted, priority: PriorityReport.values[10], category: Category.roadDamage, data: DateTime.now(), expected: 'Errore Priorità non valida', reason: 'Priorità non valida');
+  _testForm(description: 'TC_6.0_5', status:  StatusReport.values[10], priority: PriorityReport.medium, category: Category.roadDamage, data: DateTime.now(), expected: 'Errore Stato non valido', reason: 'Stato non valido');
+  _testForm(description: 'TC_6.0_6', status: StatusReport.accepted, priority: PriorityReport.medium, category: Category.roadDamage, data: DateTime.now(), expected: null, reason: 'Corretto');
+  _testForm(description: 'TC_6.0_7', status: StatusReport.accepted, priority: PriorityReport.medium, category: Category.roadDamage, data: DateTime.now(), expected: null, reason: 'Corretto');
+
+*/
 }
-/*
 void _testComune({required String description,required String input,required String? expected,required String reason}) {
   testWidgets(description, (WidgetTester tester) async {
     final key = GlobalKey<FormBuilderFieldState>();
@@ -90,9 +77,9 @@ void _testComune({required String description,required String input,required Str
 
 
   });
-}*/
+}
 
-
+/*
 void _testForm({
   required String description,
   required StatusReport status,
@@ -154,16 +141,20 @@ void _testForm({
             await tester.ensureVisible(find.text('Filtra'));
             await tester.tap(find.text('Filtra'));
             await tester.pump();
+          
 
 
 
-            expect(onSubmitCalled, false);
+            expect(onSubmitCalled, expected, reason: reason);
 
 
       
 
       });
 }
+
+
+ */
 
 
 


### PR DESCRIPTION
This pull request introduces widget tests for validating the functionality of the ‘comune’ and ‘search’ fields. Key highlights include:

- 	Validation logic to ensure the length of input does not exceed 255 characters for both fields.
- 	Test cases covering both valid and invalid scenarios for input length.
- 	Implementation of reusable test functions _testComune and _testSearch for efficient validation.



