### PR TITLE
Fix endDate when mark report as completed

### DIFF
--- a/src/lib/gestione_segnalazione_cittadino/my_segnalazioni_gui.dart
+++ b/src/lib/gestione_segnalazione_cittadino/my_segnalazioni_gui.dart
@@ -142,6 +142,7 @@ class _MyReportsListState extends State<MyReportsViewGUI> {
               priority: PriorityReport.getPriority(report['priority']) ??
                   PriorityReport.unset,
               reportDate: report['reportDate'],
+              endDate: report['endDate'],
               address: report['address'] == null
                   ? {'street': 'N/A', 'number': 'N/A'}
                   : {

--- a/src/lib/gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart
+++ b/src/lib/gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart
@@ -351,6 +351,7 @@ class _ReportsListCitizenState extends State<ReportsViewCitizenGUI> {
             priority: PriorityReport.getPriority(report['priority']) ??
                 PriorityReport.unset,
             reportDate: report['reportDate'],
+            endDate: report['endDate'],
             address: report['address'] == null
                 ? {'street': 'N/A', 'number': 'N/A'}
                 : {

--- a/src/lib/gestione_segnalazione_comune/gestione_segnalazione_comune_dao.dart
+++ b/src/lib/gestione_segnalazione_comune/gestione_segnalazione_comune_dao.dart
@@ -115,6 +115,14 @@ class MunicipalityReportManagementDAO {
           .collection('${city?.toLowerCase()}_reports')
           .doc(reportId)
           .update({'status': newStatus.name});
+      if (newStatus == StatusReport.completed) {
+        await _firestore
+            .collection('reports')
+            .doc(city?.toLowerCase())
+            .collection('${city?.toLowerCase()}_reports')
+            .doc(reportId)
+            .update({'endDate': Timestamp.now()});
+      }
     } catch (e) {
       throw const PermissionDeniedException(
           'You do not have the permissions to modify the status of the report');

--- a/src/lib/gestione_segnalazione_comune/visualizzazione_segnalazioni_comune_gui.dart
+++ b/src/lib/gestione_segnalazione_comune/visualizzazione_segnalazioni_comune_gui.dart
@@ -317,6 +317,7 @@ class _ReportsListMunicipalityState extends State<ReportsViewMunicipalityGUI> {
             priority: PriorityReport.getPriority(report['priority']) ??
                 PriorityReport.unset,
             reportDate: report['reportDate'],
+            endDate: report['endDate'],
             address: report['address'] == null
                 ? {'street': 'N/A', 'number': 'N/A'}
                 : {


### PR DESCRIPTION
# Summary

This pull request includes several changes to enhance the handling of report end dates and status updates across multiple files. The most important changes include adding the `endDate` field to report views and updating the `endDate` when a report's status is set to completed.

Enhancements to report views:

* [`src/lib/gestione_segnalazione_cittadino/my_segnalazioni_gui.dart`](diffhunk://#diff-499953250f97818cffaac7a7140b91b3bf66c42d43a4a1439c4287004db8c954R145): Added `endDate` to the report details displayed in the `_MyReportsListState` class.
* [`src/lib/gestione_segnalazione_cittadino/visualizzazione_segnalazioni_gui.dart`](diffhunk://#diff-520ffbfdd0d17c808c20837ddc42922f7077eeb46003a92f3449119f53be86edR354): Added `endDate` to the report details displayed in the `_ReportsListCitizenState` class.
* [`src/lib/gestione_segnalazione_comune/visualizzazione_segnalazioni_comune_gui.dart`](diffhunk://#diff-5c56a00e92e01522427953a51473d61382885f7053df2b5626a4535c9914f04cR320): Added `endDate` to the report details displayed in the `_ReportsListMunicipalityState` class.

Enhancements to status updates:

* [`src/lib/gestione_segnalazione_comune/gestione_segnalazione_comune_dao.dart`](diffhunk://#diff-95ec54e3c467e0fee1de5d9ea394004a48293a2225cb0be930360a208c717077R118-R125): Updated the `MunicipalityReportManagementDAO` class to set the `endDate` to the current timestamp when the report status is updated to completed.