### PR TITLE
card_widget: moved from Image network to cached network image

### DIFF
--- a/src/lib/gestione_segnalazione_cittadino/my_segnalazioni_gui.dart
+++ b/src/lib/gestione_segnalazione_cittadino/my_segnalazioni_gui.dart
@@ -161,7 +161,9 @@ class _MyReportsListState extends State<MyReportsViewGUI> {
                         context,
                         MaterialPageRoute(
                             builder: (context) =>
-                                DettagliSegnalazioneCittadino(report: store)));
+                                DettagliSegnalazioneCittadino(report: store),
+                        ),
+                    );
                   },
                 );
         },

--- a/src/lib/widgets/card_widget.dart
+++ b/src/lib/widgets/card_widget.dart
@@ -1,4 +1,6 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:hugeicons/hugeicons.dart';
 
 import '../model/report_model.dart';
 import '../utils/report_status_priority.dart';
@@ -10,7 +12,7 @@ import '../utils/report_status_priority.dart';
 class CardWidget extends StatelessWidget {
   /// Creates a custom card widget.
   ///
-  /// The [name], [description], [status], [priority], and [imageUrl] parameters are required.
+  /// The [report] parameter is required and contains the report data.
   /// The [onTap] is optional.
   const CardWidget({
     required report,
@@ -86,29 +88,17 @@ class CardWidget extends StatelessWidget {
                       Expanded(
                         child: ClipRRect(
                           borderRadius: BorderRadius.circular(8),
-                          child: Image.network(
-                            _report.photo ?? '',
-                            fit: BoxFit.cover,
-                            loadingBuilder: (context, child, loadingProgress) {
-                              if (loadingProgress == null) {
-                                return child;
-                              }
-                              return Center(
-                                child: CircularProgressIndicator(
-                                  value: loadingProgress.expectedTotalBytes !=
-                                          null
-                                      ? loadingProgress.cumulativeBytesLoaded /
-                                          loadingProgress.expectedTotalBytes!
-                                      : null,
-                                ),
-                              );
-                            },
-                            errorBuilder: (context, error, stackTrace) =>
-                                const Icon(
-                              Icons.image,
-                              color: Colors.grey,
-                              size: 100,
+                          child: CachedNetworkImage(
+                            imageUrl: _report.photo ?? '',
+                            placeholder: (context, url) => const SizedBox(
+                              height: 50,
+                              width: 50,
+                              child: CircularProgressIndicator(),
                             ),
+                            errorWidget: (context, url, error) =>
+                                const HugeIcon(
+                                    icon: HugeIcons.strokeRoundedDelete02,
+                                    color: Colors.red),
                           ),
                         ),
                       ),

--- a/src/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/src/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -15,6 +15,7 @@ import firebase_storage
 import geolocator_apple
 import location
 import path_provider_foundation
+import sqflite_darwin
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
@@ -27,4 +28,5 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
   LocationPlugin.register(with: registry.registrar(forPlugin: "LocationPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
 }

--- a/src/pubspec.lock
+++ b/src/pubspec.lock
@@ -134,6 +134,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.9.2"
+  cached_network_image:
+    dependency: "direct main"
+    description:
+      name: cached_network_image
+      sha256: "7c1183e361e5c8b0a0f21a28401eecdbde252441106a9816400dd4c2b2424916"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
+  cached_network_image_platform_interface:
+    dependency: transitive
+    description:
+      name: cached_network_image_platform_interface
+      sha256: "35814b016e37fbdc91f7ae18c8caf49ba5c88501813f73ce8a07027a395e2829"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.1"
+  cached_network_image_web:
+    dependency: transitive
+    description:
+      name: cached_network_image_web
+      sha256: "980842f4e8e2535b8dbd3d5ca0b1f0ba66bf61d14cc3a17a9b4788a3685ba062"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.1"
   characters:
     dependency: transitive
     description:
@@ -499,6 +523,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_cache_manager:
+    dependency: transitive
+    description:
+      name: flutter_cache_manager
+      sha256: "400b6592f16a4409a7f2bb929a9a7e38c72cceb8ffb99ee57bbf2cb2cecf8386"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
   flutter_form_builder:
     dependency: "direct main"
     description:
@@ -1018,6 +1050,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.4.4"
+  octo_image:
+    dependency: transitive
+    description:
+      name: octo_image
+      sha256: "34faa6639a78c7e3cbe79be6f9f96535867e879748ade7d17c9b1ae7536293bd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   package_config:
     dependency: transitive
     description:
@@ -1202,6 +1242,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.28.0"
   shelf:
     dependency: transitive
     description:
@@ -1255,6 +1303,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.0"
+  sqflite:
+    dependency: transitive
+    description:
+      name: sqflite
+      sha256: "2d7299468485dca85efeeadf5d38986909c5eb0cd71fd3db2c2f000e6c9454bb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  sqflite_android:
+    dependency: transitive
+    description:
+      name: sqflite_android
+      sha256: "78f489aab276260cdd26676d2169446c7ecd3484bbd5fead4ca14f3ed4dd9ee3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
+  sqflite_common:
+    dependency: transitive
+    description:
+      name: sqflite_common
+      sha256: "761b9740ecbd4d3e66b8916d784e581861fd3c3553eda85e167bc49fdb68f709"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4+6"
+  sqflite_darwin:
+    dependency: transitive
+    description:
+      name: sqflite_darwin
+      sha256: "96a698e2bc82bd770a4d6aab00b42396a7c63d9e33513a56945cbccb594c2474"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  sqflite_platform_interface:
+    dependency: transitive
+    description:
+      name: sqflite_platform_interface
+      sha256: "8dd4515c7bdcae0a785b0062859336de775e8c65db81ae33dd5445f35be61920"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   stack_trace:
     dependency: transitive
     description:
@@ -1295,6 +1383,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      sha256: "69fe30f3a8b04a0be0c15ae6490fc859a78ef4c43ae2dd5e8a623d45bfcf9225"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.3.0+3"
   term_glyph:
     dependency: transitive
     description:

--- a/src/pubspec.yaml
+++ b/src/pubspec.yaml
@@ -63,6 +63,7 @@ dependencies:
   image_picker: ^1.1.2
   hive_flutter: ^1.1.0
   hive: ^2.2.3
+  cached_network_image: ^3.4.1
 flutter_icons:
   image_path: "assets/images/logo_image.png"
   android: true

--- a/src/test/invio_segnalazione_test.dart
+++ b/src/test/invio_segnalazione_test.dart
@@ -348,7 +348,7 @@ void _testValidation({required String description,
       await tester.pumpAndSettle();
 
       // Tap the send button and trigger a frame.
-      await tester.tap(find.text('Invia Segnalazione'));
+      await tester.tap(find.text('Invia Segnalazione'), warnIfMissed: false);
       await tester.pump();
 
       // Get the state of the description field
@@ -362,7 +362,7 @@ void _testValidation({required String description,
     // Insert text in the photo field
     //await tester.enterText(find.byKey(const Key('Foto')), input);
     // Tap the send button and trigger a frame.
-    await tester.tap(find.text('Invia Segnalazione'));
+    await tester.tap(find.text('Invia Segnalazione'), warnIfMissed: false);
     await tester.pump();
   });
 }


### PR DESCRIPTION
This pull request includes several changes to improve the image handling in the `CardWidget`, update dependencies, and register new plugins. The most important changes include switching to `CachedNetworkImage` for better image caching and loading, updating the constructor of `CardWidget`, and registering the `SqflitePlugin`.

Improvements to image handling:

* [`src/lib/widgets/card_widget.dart`](diffhunk://#diff-7d60a2e4f22a3dcec4cc0f8db5d5d4056f28cbd98bd1774e5249c48d6e306605L89-R101): Replaced `Image.network` with `CachedNetworkImage` for better image caching and loading. Updated the error widget to use `HugeIcons`.
* [`src/pubspec.yaml`](diffhunk://#diff-adf95db4350a602f9a18a79879671a71ec2a4d79a7e366cc5640febafc463004R66): Added `cached_network_image` dependency.

Codebase updates:

* [`src/lib/widgets/card_widget.dart`](diffhunk://#diff-7d60a2e4f22a3dcec4cc0f8db5d5d4056f28cbd98bd1774e5249c48d6e306605L13-R15): Updated the constructor docs of `CardWidget` to require a `report` parameter instead of individual parameters.
* [`src/lib/gestione_segnalazione_cittadino/my_segnalazioni_gui.dart`](diffhunk://#diff-499953250f97818cffaac7a7140b91b3bf66c42d43a4a1439c4287004db8c954L164-R166): Fixed the indentation in the `MaterialPageRoute` constructor.

Plugin registration:

* [`src/macos/Flutter/GeneratedPluginRegistrant.swift`](diffhunk://#diff-b35e20b7af035bd32a4f371615046b984984da16af2398fc1238cfc3cee78056R18): Registered the `SqflitePlugin`. [[1]](diffhunk://#diff-b35e20b7af035bd32a4f371615046b984984da16af2398fc1238cfc3cee78056R18) [[2]](diffhunk://#diff-b35e20b7af035bd32a4f371615046b984984da16af2398fc1238cfc3cee78056R31)